### PR TITLE
add docker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ export LND_HOME=~/.lnd
 # build the container
 ./build.sh
 
-# run lntop from the contaner
+# run lntop from the container
 ./lntop.sh 
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,3 +39,34 @@ conn_timeout = 1000000
 pool_capacity = 3
 ```
 Change macaroon path according to your network.
+
+## Docker
+
+If you prefer to run `lntop` from a docker container:
+
+```sh
+cd docker
+
+# now you should review ./lntop/config.toml
+
+# point LND_HOME to your actual lnd directory 
+# we recommend using .envrc with direnv
+export LND_HOME=~/.lnd
+
+# build the container
+./build.sh
+
+# run lntop from the contaner
+./lntop.sh 
+```
+
+To see `lntop` logs, you can tail them in another terminal session via:
+```sh
+./logs.sh -f
+```
+
+To start from scratch:
+```sh
+./clean.sh
+./build.sh --no-cache
+```

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,1 @@
+lntop/_src

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+LND_HOME=${LND_HOME:?required}
+LNTOP_SRC_DIR=${LNTOP_SRC_DIR:-./..}
+
+# we rsync repo sources to play well with docker cache
+echo "Staging lntop source code..."
+mkdir -p lntop/_src
+rsync -a --exclude='.git/' --exclude='docker/' --exclude='README.md' --exclude='LICENSE' "$LNTOP_SRC_DIR" lntop/_src
+
+echo "Building lntop docker container..."
+exec docker-compose build "$@" lntop

--- a/docker/clean.sh
+++ b/docker/clean.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+# stop and remove all containers from lntop image (see https://stackoverflow.com/a/32074098/84283)
+CONTAINERS=$(docker ps -a -q --filter ancestor=lntop --format="{{.ID}}")
+if [[ -n "$CONTAINERS" ]]; then
+  docker rm $(docker stop ${CONTAINERS})
+fi
+
+# clean source code stage
+rm -rf lntop/_src

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,25 @@
+# we have a really simple setup here
+# we use docker-compose only as a convenient way to specify docker build parameters via a yaml file
+# you could as well use Dockerfile directly with `docker build` and config passed via command-line args
+#
+# tips:
+#   - to run lntop from docker, you can use our wrapper script ./lntop.sh
+#   - see other scripts in this folder, also check the docker section in the main readme
+
+version: '3.7'
+
+services:
+
+  lntop:
+    image: lntop
+    container_name: lntop
+    command: ["run"]
+    network_mode: host
+    build:
+      context: ./lntop
+      dockerfile: Dockerfile
+      args:
+        - LNTOP_SRC_PATH=_src
+        - LNTOP_CONF_PATH=config.toml
+    volumes:
+      - $LND_HOME:/root/.lnd

--- a/docker/inspect.sh
+++ b/docker/inspect.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+LND_HOME=${LND_HOME:?required}
+
+exec docker exec -ti lntop fish

--- a/docker/lntop.sh
+++ b/docker/lntop.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+LND_HOME=${LND_HOME:?required}
+
+exec docker-compose run --rm --name lntop lntop /sbin/tini -- lntop

--- a/docker/lntop/Dockerfile
+++ b/docker/lntop/Dockerfile
@@ -1,0 +1,45 @@
+FROM golang:1.12-alpine as builder
+
+# install build dependencies
+RUN apk add --no-cache --update git gcc musl-dev
+
+ARG LNTOP_SRC_PATH
+
+WORKDIR /root/_build
+
+# we want to populate the module cache based on the go.{mod,sum} files.
+COPY "$LNTOP_SRC_PATH/go.mod" .
+COPY "$LNTOP_SRC_PATH/go.sum" .
+
+# pre-cache deps
+# see https://container-solutions.com/faster-builds-in-docker-with-go-1-11/
+RUN go mod download
+
+WORKDIR $GOPATH/src/github.com/edouardparis/lntop
+COPY "$LNTOP_SRC_PATH" .
+
+ENV GO111MODULE=on
+RUN go install ./...
+
+# ---------------------------------------------------------------------------------------------------------------------------
+
+FROM golang:1.12-alpine as final
+
+RUN apk add --no-cache \
+    bash fish \
+    ca-certificates \
+    tini
+
+ENV PATH $PATH:/root
+
+ARG LNTOP_CONF_PATH
+
+# copy the binaries and entrypoint from the builder image.
+COPY --from=builder /go/bin/lntop /bin/
+
+WORKDIR /root
+
+COPY "home" .
+
+RUN mkdir ".lntop"
+COPY "$LNTOP_CONF_PATH" ".lntop/"

--- a/docker/lntop/Dockerfile
+++ b/docker/lntop/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR $GOPATH/src/github.com/edouardparis/lntop
 COPY "$LNTOP_SRC_PATH" .
 
 ENV GO111MODULE=on
-RUN go install ./...
+RUN go install -mod=vendor ./...
 
 # ---------------------------------------------------------------------------------------------------------------------------
 

--- a/docker/lntop/config.toml
+++ b/docker/lntop/config.toml
@@ -1,0 +1,14 @@
+[logger]
+type = "development" # "production"
+dest = "/root/.lntop/lntop.log"
+
+[network]
+name = "lnd"
+type = "lnd"
+address = "//127.0.0.1:10009"
+cert = "/root/.lnd/tls.cert"
+macaroon = "/root/.lnd/data/chain/bitcoin/mainnet/admin.macaroon"
+macaroon_timeout = 60
+max_msg_recv_size = 52428800
+conn_timeout = 1000000
+pool_capacity = 3

--- a/docker/lntop/home/run
+++ b/docker/lntop/home/run
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+if [[ ! $# -eq 0 ]]; then
+  exec "$@"
+fi
+
+echo "this docker-compose service is not designed to be launched via docker-compose up"
+echo "exec lntop via ./lntop.sh or directly via docker, e.g. \`docker exec -ti lntop lntop\`"
+exit 1

--- a/docker/logs.sh
+++ b/docker/logs.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+LND_HOME=${LND_HOME:?required}
+
+exec docker exec lntop tail /root/.lntop/lntop.log "$@"


### PR DESCRIPTION
Hi, nice job on lntop. 

I've added initial support for running it from docker.

I have tested it on my Ubuntu 18.10 VPS running mainnet lnd in another docker container with data folder mapped to host machine - it works fine. 

The only problem is on exit (F10). I don't think lntop is exiting cleanly. It must be forced via CTRL+C or when waiting enough it fails with

```
panic: send on closed channel

goroutine 12 [running]:
github.com/edouardparis/lntop/pubsub.(*pubSub).ticker.func1(0xc000151b90, 0xc00008f4a0, 0xc481c0, 0xc000038048, 0xc000076b40)
	/go/src/github.com/edouardparis/lntop/pubsub/pubsub.go:55 +0x30a
created by github.com/edouardparis/lntop/pubsub.(*pubSub).ticker
	/go/src/github.com/edouardparis/lntop/pubsub/pubsub.go:36 +0x94
```

This is probably worth a separate ticket.