### PR TITLE
docker: tail logs from host

### DIFF
--- a/docker/logs.sh
+++ b/docker/logs.sh
@@ -4,4 +4,4 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 . _settings.sh
 
-exec docker exec lntop tail /root/.lntop/lntop.log "$@"
+exec tail "$@" "$LNTOP_HOME/lntop.log"


### PR DESCRIPTION
now that we have the log mapped to host folder we can simply tail it there