### PR TITLE
Constrain the cursor and prevent segfaults

### DIFF
--- a/ui/views/channels.go
+++ b/ui/views/channels.go
@@ -83,6 +83,9 @@ func (c Channels) currentColumnIndex() int {
 func (c Channels) Sort(column string, order models.Order) {
 	if column == "" {
 		index := c.currentColumnIndex()
+		if index >= len(c.columns) {
+			return
+		}
 		col := c.columns[index]
 		if col.sort == nil {
 			return
@@ -134,15 +137,23 @@ func (c *Channels) SetOrigin(ox, oy int) error {
 
 func (c *Channels) Speed() (int, int, int, int) {
 	current := c.currentColumnIndex()
+	up := 0
+	down := 0
+	if c.Index() > 0 {
+		up = 1
+	}
+	if c.Index() < c.channels.Len()-1 {
+		down = 1
+	}
 	if current > len(c.columns)-1 {
-		return 0, c.columns[current-1].width + 1, 1, 1
+		return 0, c.columns[current-1].width + 1, down, up
 	}
 	if current == 0 {
-		return c.columns[0].width + 1, 0, 1, 1
+		return c.columns[0].width + 1, 0, down, up
 	}
 	return c.columns[current].width + 1,
 		c.columns[current-1].width + 1,
-		1, 1
+		down, up
 }
 
 func (c Channels) Index() int {

--- a/ui/views/menu.go
+++ b/ui/views/menu.go
@@ -42,7 +42,11 @@ func (h Menu) Cursor() (int, int) {
 }
 
 func (h Menu) Speed() (int, int, int, int) {
-	return 0, 0, 1, 1
+	down := 0
+	if h.cy+h.oy < len(menu)-1 {
+		down = 1
+	}
+	return 0, 0, down, 1
 }
 
 func (h *Menu) SetCursor(x, y int) error {

--- a/ui/views/transactions.go
+++ b/ui/views/transactions.go
@@ -117,20 +117,31 @@ func (c *Transactions) SetOrigin(ox, oy int) error {
 
 func (c *Transactions) Speed() (int, int, int, int) {
 	current := c.currentColumnIndex()
+	up := 0
+	down := 0
+	if c.Index() > 0 {
+		up = 1
+	}
+	if c.Index() < c.transactions.Len()-1 {
+		down = 1
+	}
 	if current > len(c.columns)-1 {
-		return 0, c.columns[current-1].width + 1, 1, 1
+		return 0, c.columns[current-1].width + 1, down, up
 	}
 	if current == 0 {
-		return c.columns[0].width + 1, 0, 1, 1
+		return c.columns[0].width + 1, 0, down, up
 	}
 	return c.columns[current].width + 1,
 		c.columns[current-1].width + 1,
-		1, 1
+		down, up
 }
 
 func (c *Transactions) Sort(column string, order models.Order) {
 	if column == "" {
 		index := c.currentColumnIndex()
+		if index >= len(c.columns) {
+			return
+		}
 		col := c.columns[index]
 		if col.sort == nil {
 			return


### PR DESCRIPTION
This PR fixes two issues:
1) the cursor can move past the last channel or transaction; pressing Enter when it's not positioned on a valid item causes segmentation fault
2) the cursor can be positioned after the last channel/tx column; trying to sort while it's there also causes segfault