### PR TITLE
Improve policies view and restrict cursor in detail views

### DIFF
--- a/network/backend/lnd/lnd.go
+++ b/network/backend/lnd/lnd.go
@@ -354,6 +354,14 @@ func (l Backend) GetChannelInfo(ctx context.Context, channel *models.Channel) er
 	channel.Policy1 = protoToRoutingPolicy(resp.Node1Policy)
 	channel.Policy2 = protoToRoutingPolicy(resp.Node2Policy)
 
+	info, err := clt.GetInfo(ctx, &lnrpc.GetInfoRequest{})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if info != nil {
+		channel.WeFirst = resp.Node1Pub == info.IdentityPubkey
+	}
+
 	return nil
 }
 

--- a/network/models/channel.go
+++ b/network/models/channel.go
@@ -48,6 +48,7 @@ type Channel struct {
 	PendingHTLC         []*HTLC
 	LastUpdate          *time.Time
 	Node                *Node
+	WeFirst             bool
 	Policy1             *RoutingPolicy
 	Policy2             *RoutingPolicy
 }

--- a/ui/cursor/cursor.go
+++ b/ui/cursor/cursor.go
@@ -14,10 +14,14 @@ func Down(v View) error {
 		return nil
 	}
 	cx, cy := v.Cursor()
+	ox, oy := v.Origin()
 	_, _, sy, _ := v.Speed()
+	_, fs := v.Limits()
+	if cy+oy+sy >= fs {
+		return nil
+	}
 	err := v.SetCursor(cx, cy+sy)
 	if err != nil {
-		ox, oy := v.Origin()
 		err := v.SetOrigin(ox, oy+sy)
 		if err != nil {
 			return err

--- a/ui/views/channel.go
+++ b/ui/views/channel.go
@@ -49,7 +49,9 @@ func (c Channel) Speed() (int, int, int, int) {
 }
 
 func (c Channel) Limits() (pageSize int, fullSize int) {
-	return 0, 0
+	_, pageSize = c.view.Size()
+	fullSize = len(c.view.BufferLines()) - 1
+	return
 }
 
 func (c *Channel) SetCursor(x, y int) error {

--- a/ui/views/channel.go
+++ b/ui/views/channel.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
 
+	netModels "github.com/edouardparis/lntop/network/models"
 	"github.com/edouardparis/lntop/ui/color"
 	"github.com/edouardparis/lntop/ui/models"
 )
@@ -93,12 +94,12 @@ func (c *Channel) Set(g *gocui.Gui, x0, y0, x1, y1 int) error {
 	footer.FgColor = gocui.ColorBlack
 	footer.Clear()
 	blackBg := color.Black(color.Background)
-	fmt.Fprintln(footer, fmt.Sprintf("%s%s %s%s %s%s %s%s",
+	fmt.Fprintf(footer, "%s%s %s%s %s%s %s%s\n",
 		blackBg("F1"), "Help",
 		blackBg("F2"), "Menu",
 		blackBg("Enter"), "Channels",
 		blackBg("F10"), "Quit",
-	))
+	)
 	return nil
 }
 
@@ -116,6 +117,29 @@ func (c Channel) Delete(g *gocui.Gui) error {
 	return g.DeleteView(CHANNEL_FOOTER)
 }
 
+func printPolicy(v *gocui.View, p *message.Printer, policy *netModels.RoutingPolicy, outgoing bool) {
+	green := color.Green()
+	cyan := color.Cyan()
+	red := color.Red()
+	fmt.Fprintln(v, "")
+	direction := "Outgoing"
+	if !outgoing {
+		direction = "Incoming"
+	}
+	fmt.Fprintf(v, green(" [ %s Policy ]\n"), direction)
+	if policy.Disabled {
+		fmt.Fprintln(v, red("disabled"))
+	}
+	fmt.Fprintf(v, "%s %d\n",
+		cyan("    Time lock delta:"), policy.TimeLockDelta)
+	fmt.Fprintf(v, "%s %d\n",
+		cyan("           Min htlc:"), policy.MinHtlc)
+	fmt.Fprintf(v, "%s %d\n",
+		cyan("      Fee base msat:"), policy.FeeBaseMsat)
+	fmt.Fprintf(v, "%s %d\n",
+		cyan("Fee rate milli msat:"), policy.FeeRateMilliMsat)
+}
+
 func (c *Channel) display() {
 	p := message.NewPrinter(language.English)
 	v := c.view
@@ -123,64 +147,43 @@ func (c *Channel) display() {
 	channel := c.channels.Current()
 	green := color.Green()
 	cyan := color.Cyan()
-	red := color.Red()
 	fmt.Fprintln(v, green(" [ Channel ]"))
-	fmt.Fprintln(v, fmt.Sprintf("%s %s",
-		cyan("         Status:"), status(channel)))
-	fmt.Fprintln(v, fmt.Sprintf("%s %d",
-		cyan("             ID:"), channel.ID))
-	fmt.Fprintln(v, p.Sprintf("%s %d",
-		cyan("       Capacity:"), channel.Capacity))
-	fmt.Fprintln(v, p.Sprintf("%s %d",
-		cyan("  Local Balance:"), channel.LocalBalance))
-	fmt.Fprintln(v, p.Sprintf("%s %d",
-		cyan(" Remote Balance:"), channel.RemoteBalance))
-	fmt.Fprintln(v, fmt.Sprintf("%s %s",
-		cyan("  Channel Point:"), channel.ChannelPoint))
+	fmt.Fprintf(v, "%s %s\n",
+		cyan("         Status:"), status(channel))
+	fmt.Fprintf(v, "%s %d\n",
+		cyan("             ID:"), channel.ID)
+	fmt.Fprintf(v, "%s %d\n",
+		cyan("       Capacity:"), channel.Capacity)
+	fmt.Fprintf(v, "%s %d\n",
+		cyan("  Local Balance:"), channel.LocalBalance)
+	fmt.Fprintf(v, "%s %d\n",
+		cyan(" Remote Balance:"), channel.RemoteBalance)
+	fmt.Fprintf(v, "%s %s\n",
+		cyan("  Channel Point:"), channel.ChannelPoint)
 	fmt.Fprintln(v, "")
 	fmt.Fprintln(v, green(" [ Node ]"))
-	fmt.Fprintln(v, fmt.Sprintf("%s %s",
-		cyan("         PubKey:"), channel.RemotePubKey))
+	fmt.Fprintf(v, "%s %s\n",
+		cyan("         PubKey:"), channel.RemotePubKey)
 
 	if channel.Node != nil {
-		fmt.Fprintln(v, fmt.Sprintf("%s %s",
-			cyan("          Alias:"), channel.Node.Alias))
-		fmt.Fprintln(v, p.Sprintf("%s %d",
-			cyan(" Total Capacity:"), channel.Node.TotalCapacity))
-		fmt.Fprintln(v, p.Sprintf("%s %d",
-			cyan(" Total Channels:"), channel.Node.NumChannels))
+		fmt.Fprintf(v, "%s %s\n",
+			cyan("          Alias:"), channel.Node.Alias)
+		fmt.Fprintf(v, "%s %d\n",
+			cyan(" Total Capacity:"), channel.Node.TotalCapacity)
+		fmt.Fprintf(v, "%s %d\n",
+			cyan(" Total Channels:"), channel.Node.NumChannels)
 	}
 
-	if channel.Policy1 != nil {
-		fmt.Fprintln(v, "")
-		fmt.Fprintln(v, green(" [ Forward Policy Node 1 ]"))
-		if channel.Policy1.Disabled {
-			fmt.Fprintln(v, red("disabled"))
-		}
-		fmt.Fprintln(v, p.Sprintf("%s %d",
-			cyan("    Time lock delta:"), channel.Policy1.TimeLockDelta))
-		fmt.Fprintln(v, p.Sprintf("%s %d",
-			cyan("           Min htlc:"), channel.Policy1.MinHtlc))
-		fmt.Fprintln(v, p.Sprintf("%s %d",
-			cyan("      Fee base msat:"), channel.Policy1.FeeBaseMsat))
-		fmt.Fprintln(v, p.Sprintf("%s %d",
-			cyan("Fee rate milli msat:"), channel.Policy1.FeeRateMilliMsat))
+	if channel.Policy1 != nil && channel.WeFirst {
+		printPolicy(v, p, channel.Policy1, true)
 	}
 
 	if channel.Policy2 != nil {
-		fmt.Fprintln(v, "")
-		fmt.Fprintln(v, green(" [ Forward Policy Node 2 ]"))
-		if channel.Policy2.Disabled {
-			fmt.Fprintln(v, red("disabled"))
-		}
-		fmt.Fprintln(v, p.Sprintf("%s %d",
-			cyan("    Time lock delta:"), channel.Policy2.TimeLockDelta))
-		fmt.Fprintln(v, p.Sprintf("%s %d",
-			cyan("           Min htlc:"), channel.Policy2.MinHtlc))
-		fmt.Fprintln(v, p.Sprintf("%s %d",
-			cyan("      Fee base msat:"), channel.Policy2.FeeBaseMsat))
-		fmt.Fprintln(v, p.Sprintf("%s %d",
-			cyan("Fee rate milli msat:"), channel.Policy2.FeeRateMilliMsat))
+		printPolicy(v, p, channel.Policy2, !channel.WeFirst)
+	}
+
+	if channel.Policy1 != nil && !channel.WeFirst {
+		printPolicy(v, p, channel.Policy1, false)
 	}
 }
 

--- a/ui/views/help.go
+++ b/ui/views/help.go
@@ -43,7 +43,9 @@ func (h Help) Speed() (int, int, int, int) {
 }
 
 func (h Help) Limits() (pageSize int, fullSize int) {
-	return 0, 0
+	_, pageSize = h.view.Size()
+	fullSize = len(h.view.BufferLines()) - 1
+	return
 }
 
 func (h *Help) SetCursor(x, y int) error {

--- a/ui/views/routing.go
+++ b/ui/views/routing.go
@@ -137,6 +137,9 @@ func (c *Routing) Speed() (int, int, int, int) {
 func (c *Routing) Limits() (pageSize int, fullSize int) {
 	_, pageSize = c.view.Size()
 	fullSize = len(c.routingEvents.Log)
+	if pageSize < fullSize {
+		fullSize = pageSize
+	}
 	return
 }
 

--- a/ui/views/transaction.go
+++ b/ui/views/transaction.go
@@ -48,7 +48,9 @@ func (c Transaction) Speed() (int, int, int, int) {
 }
 
 func (c Transaction) Limits() (pageSize int, fullSize int) {
-	return 0, 0
+	_, pageSize = c.view.Size()
+	fullSize = len(c.view.BufferLines()) - 1
+	return
 }
 
 func (c *Transaction) SetCursor(x, y int) error {


### PR DESCRIPTION
One thing that's been bugging me is lack of details regarding fee policies in the channel details view. It's not obvious which node is first and which is second (it's basically random). This PR fixes three things:
- policies renamed to `Outgoing` (for our side of the channels) and `Incoming` (for the opposite side that we don't control)
- our side is always displayed first because it's arguably more important
- cursor movements are restricted to the actual data lines in the detail views (channels, transactions and help) so we can't scroll past it anymore; before it was only fixed for the list views