### PR TITLE
Add short channel id columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ columns = [
 	"LAST UPDATE", # last update of the channel
 	"PRIVATE",     # true if channel is private
 	"ID",          # the id of the channel
+	# "SCID",      # short channel id (BxTxO formatted)
 ]
 
 [views.transactions]
@@ -79,10 +80,12 @@ columns = [
 	"STATUS",         # one of: active, settled, failed, linkfail
 	"IN_CHANNEL",     # channel id of the incomming channel
 	"IN_ALIAS",       # incoming channel node alias
+	# "IN_SCID",      # incoming short channel id (BxTxO)
 	# "IN_HTLC",      # htlc id on incoming channel
 	# "IN_TIMELOCK",  # incoming timelock height
 	"OUT_CHANNEL",    # channel id of the outgoing channel
 	"OUT_ALIAS",      # outgoing channel node alias
+	# "OUT_SCID",     # outgoing short channel id (BxTxO)
 	# "OUT_HTLC",     # htlc id on outgoing channel
 	# "OUT_TIMELOCK", # outgoing timelock height
 	"AMOUNT",         # routed amount

--- a/config/default.go
+++ b/config/default.go
@@ -43,6 +43,7 @@ columns = [
 	"LAST UPDATE", # last update of the channel
 	"PRIVATE",     # true if channel is private
 	"ID",          # the id of the channel
+	# "SCID",      # short channel id (BxTxO formatted)
 ]
 
 [views.transactions]
@@ -63,10 +64,12 @@ columns = [
 	"STATUS",         # one of: active, settled, failed, linkfail
 	"IN_CHANNEL",     # channel id of the incomming channel
 	"IN_ALIAS",       # incoming channel node alias
+	# "IN_SCID",      # incoming short channel id (BxTxO)
 	# "IN_HTLC",      # htlc id on incoming channel
 	# "IN_TIMELOCK",  # incoming timelock height
 	"OUT_CHANNEL",    # channel id of the outgoing channel
 	"OUT_ALIAS",      # outgoing channel node alias
+	# "OUT_SCID",     # outgoing short channel id (BxTxO)
 	# "OUT_HTLC",     # htlc id on outgoing channel
 	# "OUT_TIMELOCK", # outgoing timelock height
 	"AMOUNT",         # routed amount

--- a/ui/views/channel.go
+++ b/ui/views/channel.go
@@ -152,8 +152,8 @@ func (c *Channel) display() {
 	fmt.Fprintln(v, green(" [ Channel ]"))
 	fmt.Fprintf(v, "%s %s\n",
 		cyan("         Status:"), status(channel))
-	fmt.Fprintf(v, "%s %d\n",
-		cyan("             ID:"), channel.ID)
+	fmt.Fprintf(v, "%s %d (%s)\n",
+		cyan("             ID:"), channel.ID, ToScid(channel.ID))
 	fmt.Fprintf(v, "%s %d\n",
 		cyan("       Capacity:"), channel.Capacity)
 	fmt.Fprintf(v, "%s %d\n",

--- a/ui/views/channels.go
+++ b/ui/views/channels.go
@@ -478,6 +478,17 @@ func NewChannels(cfg *config.View, chans *models.Channels) *Channels {
 					return color.White(opts...)(fmt.Sprintf("%d", c.ID))
 				},
 			}
+		case "SCID":
+			channels.columns[i] = channelsColumn{
+				width: 14,
+				name:  fmt.Sprintf("%-14s", columns[i]),
+				display: func(c *netmodels.Channel, opts ...color.Option) string {
+					if c.ID == 0 {
+						return fmt.Sprintf("%-14s", "")
+					}
+					return color.White(opts...)(fmt.Sprintf("%-14s", ToScid(c.ID)))
+				},
+			}
 		default:
 			channels.columns[i] = channelsColumn{
 				width: 21,

--- a/ui/views/routing.go
+++ b/ui/views/routing.go
@@ -309,6 +309,17 @@ func NewRouting(cfg *config.View, routingEvents *models.RoutingLog, channels *mo
 					return color.White(opts...)(fmt.Sprintf("%19d", c.IncomingChannelId))
 				},
 			}
+		case "IN_SCID":
+			routing.columns[i] = routingColumn{
+				width: 14,
+				name:  fmt.Sprintf("%14s", columns[i]),
+				display: func(c *netmodels.RoutingEvent, opts ...color.Option) string {
+					if c.IncomingChannelId == 0 {
+						return fmt.Sprintf("%14s", "")
+					}
+					return color.White(opts...)(fmt.Sprintf("%14s", ToScid(c.IncomingChannelId)))
+				},
+			}
 		case "IN_TIMELOCK":
 			routing.columns[i] = routingColumn{
 				width: 10,
@@ -346,6 +357,17 @@ func NewRouting(cfg *config.View, routingEvents *models.RoutingLog, channels *mo
 						return fmt.Sprintf("%19s", "")
 					}
 					return color.White(opts...)(fmt.Sprintf("%19d", c.OutgoingChannelId))
+				},
+			}
+		case "OUT_SCID":
+			routing.columns[i] = routingColumn{
+				width: 14,
+				name:  fmt.Sprintf("%14s", columns[i]),
+				display: func(c *netmodels.RoutingEvent, opts ...color.Option) string {
+					if c.OutgoingChannelId == 0 {
+						return fmt.Sprintf("%14s", "")
+					}
+					return color.White(opts...)(fmt.Sprintf("%14s", ToScid(c.OutgoingChannelId)))
 				},
 			}
 		case "OUT_TIMELOCK":

--- a/ui/views/views.go
+++ b/ui/views/views.go
@@ -1,6 +1,8 @@
 package views
 
 import (
+	"fmt"
+
 	"github.com/jroimartin/gocui"
 	"github.com/pkg/errors"
 
@@ -112,4 +114,12 @@ func New(cfg config.Views, m *models.Models) *Views {
 		Routing:      NewRouting(cfg.Routing, m.RoutingLog, m.Channels),
 		Main:         main,
 	}
+}
+
+func ToScid(id uint64) string {
+	blocknum := id >> 40
+	txnum := (id >> 16) & 0x00FFFFFF
+	outnum := id & 0xFFFF
+
+	return fmt.Sprintf("%dx%dx%d", blocknum, txnum, outnum)
 }


### PR DESCRIPTION
SCID represents the same information as channel id but uses different formatting exposing the three components (block height, transaction index, output index). LN software seems to pick one of these formats at random so I suppose it's better to support both.