### PR TITLE
Allow sorting by all columns

### DIFF
--- a/ui/models/sort.go
+++ b/ui/models/sort.go
@@ -1,6 +1,9 @@
 package models
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 type Order int
 
@@ -30,6 +33,13 @@ func Int64Sort(a, b int64, o Order) bool {
 	return a > b
 }
 
+func UInt64Sort(a, b uint64, o Order) bool {
+	if o == Asc {
+		return a < b
+	}
+	return a > b
+}
+
 func DateSort(a, b *time.Time, o Order) bool {
 	if o == Desc {
 		if a == nil || b == nil {
@@ -44,4 +54,19 @@ func DateSort(a, b *time.Time, o Order) bool {
 	}
 
 	return a.Before(*b)
+}
+
+func StringSort(a, b string, o Order) bool {
+	result := strings.Compare(a, b)
+	if o == Asc {
+		return result < 0
+	}
+	return result > 0
+}
+
+func BoolSort(a, b bool, o Order) bool {
+	if o == Asc {
+		return !a && b
+	}
+	return a && !b
 }

--- a/ui/views/channels.go
+++ b/ui/views/channels.go
@@ -297,14 +297,25 @@ func NewChannels(cfg *config.View, chans *models.Channels) *Channels {
 		switch columns[i] {
 		case "STATUS":
 			channels.columns[i] = channelsColumn{
-				width:   13,
-				name:    fmt.Sprintf("%-13s", columns[i]),
+				width: 13,
+				name:  fmt.Sprintf("%-13s", columns[i]),
+				sort: func(order models.Order) models.ChannelsSort {
+					return func(c1, c2 *netmodels.Channel) bool {
+						// status meanings are kinda the opposite of their numerical value
+						return models.IntSort(-c1.Status, -c2.Status, order)
+					}
+				},
 				display: status,
 			}
 		case "ALIAS":
 			channels.columns[i] = channelsColumn{
 				width: 25,
 				name:  fmt.Sprintf("%-25s", columns[i]),
+				sort: func(order models.Order) models.ChannelsSort {
+					return func(c1, c2 *netmodels.Channel) bool {
+						return models.StringSort(c1.Node.Alias, c2.Node.Alias, order)
+					}
+				},
 				display: func(c *netmodels.Channel, opts ...color.Option) string {
 					var alias string
 					if c.Node == nil || c.Node.Alias == "" {
@@ -460,6 +471,12 @@ func NewChannels(cfg *config.View, chans *models.Channels) *Channels {
 			channels.columns[i] = channelsColumn{
 				width: 7,
 				name:  fmt.Sprintf("%-7s", columns[i]),
+				sort: func(order models.Order) models.ChannelsSort {
+					return func(c1, c2 *netmodels.Channel) bool {
+						// public > private
+						return models.BoolSort(!c1.Private, !c2.Private, order)
+					}
+				},
 				display: func(c *netmodels.Channel, opts ...color.Option) string {
 					if c.Private {
 						return color.Red(opts...)("private")
@@ -471,6 +488,11 @@ func NewChannels(cfg *config.View, chans *models.Channels) *Channels {
 			channels.columns[i] = channelsColumn{
 				width: 19,
 				name:  fmt.Sprintf("%-19s", columns[i]),
+				sort: func(order models.Order) models.ChannelsSort {
+					return func(c1, c2 *netmodels.Channel) bool {
+						return models.UInt64Sort(c1.ID, c2.ID, order)
+					}
+				},
 				display: func(c *netmodels.Channel, opts ...color.Option) string {
 					if c.ID == 0 {
 						return fmt.Sprintf("%-19s", "")
@@ -482,6 +504,11 @@ func NewChannels(cfg *config.View, chans *models.Channels) *Channels {
 			channels.columns[i] = channelsColumn{
 				width: 14,
 				name:  fmt.Sprintf("%-14s", columns[i]),
+				sort: func(order models.Order) models.ChannelsSort {
+					return func(c1, c2 *netmodels.Channel) bool {
+						return models.UInt64Sort(c1.ID, c2.ID, order)
+					}
+				},
 				display: func(c *netmodels.Channel, opts ...color.Option) string {
 					if c.ID == 0 {
 						return fmt.Sprintf("%-14s", "")


### PR DESCRIPTION
Some columns don't allow sorting for some reason but it's actually very useful. It's easier to find a channel by its name when they're sorted by it. Or find your oldest and newest ones (sort by the channel ID). Or group those inactive channels together. Endless possibilities!