### PR TITLE
Add forced aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ max_msg_recv_size = 52428800
 conn_timeout = 1000000
 pool_capacity = 4
 
+[network.aliases]
+# Not all peers have aliases set up. In order to remember who is whom, pubkeys can be annotated.
+# "Forced" aliases will be printed in a different color to be distinguished from network advertised aliases.
+035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226 = "Wallet of Satoshi"
+03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f = "-=[ACINQ]=-"
+
 [views]
 # views.channels is the view displaying channel list.
 [views.channels]

--- a/config/config.go
+++ b/config/config.go
@@ -23,16 +23,17 @@ type Logger struct {
 }
 
 type Network struct {
-	Name            string `toml:"name"`
-	Type            string `toml:"type"`
-	Address         string `toml:"address"`
-	Cert            string `toml:"cert"`
-	Macaroon        string `toml:"macaroon"`
-	MacaroonTimeOut int64  `toml:"macaroon_timeout"`
-	MacaroonIP      string `toml:"macaroon_ip"`
-	MaxMsgRecvSize  int    `toml:"max_msg_recv_size"`
-	ConnTimeout     int    `toml:"conn_timeout"`
-	PoolCapacity    int    `toml:"pool_capacity"`
+	Name            string  `toml:"name"`
+	Type            string  `toml:"type"`
+	Address         string  `toml:"address"`
+	Cert            string  `toml:"cert"`
+	Macaroon        string  `toml:"macaroon"`
+	MacaroonTimeOut int64   `toml:"macaroon_timeout"`
+	MacaroonIP      string  `toml:"macaroon_ip"`
+	MaxMsgRecvSize  int     `toml:"max_msg_recv_size"`
+	ConnTimeout     int     `toml:"conn_timeout"`
+	PoolCapacity    int     `toml:"pool_capacity"`
+	Aliases         Aliases `toml:"aliases"`
 }
 
 type Views struct {
@@ -44,6 +45,8 @@ type Views struct {
 type View struct {
 	Columns []string `toml:"columns"`
 }
+
+type Aliases map[string]string
 
 func Load(path string) (*Config, error) {
 	c := &Config{}

--- a/network/backend/lnd/lnd.go
+++ b/network/backend/lnd/lnd.go
@@ -379,8 +379,11 @@ func (l Backend) GetNode(ctx context.Context, pubkey string) (*models.Node, erro
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-
-	return nodeProtoToNode(resp), nil
+	result := nodeProtoToNode(resp)
+	if forcedAlias, ok := l.cfg.Aliases[result.PubKey]; ok {
+		result.ForcedAlias = forcedAlias
+	}
+	return result, nil
 }
 
 func (l Backend) CreateInvoice(ctx context.Context, amount int64, desc string) (*models.Invoice, error) {

--- a/network/models/channel.go
+++ b/network/models/channel.go
@@ -72,6 +72,21 @@ func (m Channel) MarshalLogObject(enc logging.ObjectEncoder) error {
 	return nil
 }
 
+func (m Channel) ShortAlias() (alias string, forced bool) {
+	if m.Node != nil && m.Node.ForcedAlias != "" {
+		alias = m.Node.ForcedAlias
+		forced = true
+	} else if m.Node == nil || m.Node.Alias == "" {
+		alias = m.RemotePubKey[:24]
+	} else {
+		alias = m.Node.Alias
+	}
+	if len(alias) > 25 {
+		alias = alias[:24]
+	}
+	return
+}
+
 type ChannelUpdate struct {
 }
 

--- a/network/models/node.go
+++ b/network/models/node.go
@@ -8,6 +8,7 @@ type Node struct {
 	LastUpdate    time.Time
 	PubKey        string
 	Alias         string
+	ForcedAlias   string
 	Addresses     []*NodeAddress
 }
 

--- a/ui/views/channel.go
+++ b/ui/views/channel.go
@@ -167,8 +167,12 @@ func (c *Channel) display() {
 		cyan("         PubKey:"), channel.RemotePubKey)
 
 	if channel.Node != nil {
+		alias, forced := channel.ShortAlias()
+		if forced {
+			alias = cyan(alias)
+		}
 		fmt.Fprintf(v, "%s %s\n",
-			cyan("          Alias:"), channel.Node.Alias)
+			cyan("          Alias:"), alias)
 		fmt.Fprintf(v, "%s %d\n",
 			cyan(" Total Capacity:"), channel.Node.TotalCapacity)
 		fmt.Fprintf(v, "%s %d\n",

--- a/ui/views/channels.go
+++ b/ui/views/channels.go
@@ -316,15 +316,12 @@ func NewChannels(cfg *config.View, chans *models.Channels) *Channels {
 					}
 				},
 				display: func(c *netmodels.Channel, opts ...color.Option) string {
-					var alias string
-					if c.Node == nil || c.Node.Alias == "" {
-						alias = c.RemotePubKey[:24]
-					} else if len(c.Node.Alias) > 25 {
-						alias = c.Node.Alias[:24]
-					} else {
-						alias = c.Node.Alias
+					aliasColor := color.White(opts...)
+					alias, forced := c.ShortAlias()
+					if forced {
+						aliasColor = color.Cyan(opts...)
 					}
-					return color.White(opts...)(fmt.Sprintf("%-25s", alias))
+					return aliasColor(fmt.Sprintf("%-25s", alias))
 				},
 			}
 		case "GAUGE":

--- a/ui/views/routing.go
+++ b/ui/views/routing.go
@@ -477,18 +477,17 @@ func ralias(channels *models.Channels, out bool) func(*netmodels.RoutingEvent, .
 		}
 
 		var alias string
+		var forced bool
+		aliasColor := color.White(opts...)
 		for _, ch := range channels.List() {
 			if ch.ID == id {
-				if ch.Node == nil || ch.Node.Alias == "" {
-					alias = ch.RemotePubKey[:24]
-				} else if len(ch.Node.Alias) > 25 {
-					alias = ch.Node.Alias[:24]
-				} else {
-					alias = ch.Node.Alias
+				alias, forced = ch.ShortAlias()
+				if forced {
+					aliasColor = color.Cyan(opts...)
 				}
 				break
 			}
 		}
-		return color.White(opts...)(fmt.Sprintf("%-25s", alias))
+		return aliasColor(fmt.Sprintf("%-25s", alias))
 	}
 }


### PR DESCRIPTION
I have plenty of channels and not all peers have aliases set up. For private channels it's not even expected. However, if you test and use multiple non-custodial wallets that open real channels to your node you might want to know which is which and remembering the hex digits quickly becomes tedious. So I added this handy feature. Now you can force an alias for any node (including those already having an alias, just in case!) and it will be printed in cyan everywhere unlike the "real" aliases. That way you won't forget that this one comes from the config file. Adding these aliases is simple:

```
[network.aliases]
035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226 = "Wallet of Satoshi"
03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f = "-=[ACINQ]=-"
```
And so on, `pubkey = "your personal alias"`. They're still truncated to 25 chars in all views, just like the regular ones. What it looks like:
![2021-11-27_16-34-00](https://user-images.githubusercontent.com/184066/143683746-617f0101-cf5e-42f2-9d1d-76b770018e76.png)

Now, before merging this should be documented somehow and I'm not sure if I just add the example above to README or write it in a more generic form. Tell me what you think!