### PR TITLE
Make gauge sort more stable

### DIFF
--- a/ui/models/sort.go
+++ b/ui/models/sort.go
@@ -33,6 +33,13 @@ func Int64Sort(a, b int64, o Order) bool {
 	return a > b
 }
 
+func Float64Sort(a, b float64, o Order) bool {
+	if o == Asc {
+		return a < b
+	}
+	return a > b
+}
+
 func UInt64Sort(a, b uint64, o Order) bool {
 	if o == Asc {
 		return a < b

--- a/ui/views/channels.go
+++ b/ui/views/channels.go
@@ -330,9 +330,9 @@ func NewChannels(cfg *config.View, chans *models.Channels) *Channels {
 				name:  fmt.Sprintf("%-21s", columns[i]),
 				sort: func(order models.Order) models.ChannelsSort {
 					return func(c1, c2 *netmodels.Channel) bool {
-						return models.Int64Sort(
-							c1.LocalBalance*100/c1.Capacity,
-							c2.LocalBalance*100/c2.Capacity,
+						return models.Float64Sort(
+							float64(c1.LocalBalance)*100/float64(c1.Capacity),
+							float64(c2.LocalBalance)*100/float64(c2.Capacity),
 							order)
 					}
 				},


### PR DESCRIPTION
From the Go standard library description:
```go
// Sort sorts data.
// It makes one call to data.Len to determine n and O(n*log(n)) calls to
// data.Less and data.Swap. The sort is not guaranteed to be stable.
func Sort(data Interface) {
```
The sort is indeed not stable i.e. it will sort the equal elements in random order. Most elements in the grid don't suffer from that as they're all unique enough or they're not sorted by too often but `gauge` isn't one of them. It currently uses integer math to calculate the percentage and the collisions are real when the number of channels is high enough. It results in different order of channels every time you sort by the `gauge` column, a couple or sometimes three channels swap places. Doesn't look good. And sometimes those two channels have different gauge length due to rounding errors (the gauge is only 15 chars long) so a channel with a longer gauge ends up below a shorter one even when the order is descending, it looks like a bug.

Here I replaced the gauge order calculation with float math that provides much more precise results and the order always stays stable.