### PR TITLE
Add remote balance and update count columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ columns = [
 	"ALIAS",       # alias of the channel node
 	"GAUGE",       # ascii bar with percent local/capacity
 	"LOCAL",       # the local amount of the channel
+	# "REMOTE",    # the remote amount of the channel
 	"CAP",         # the total capacity of the channel
 	"SENT",        # the total amount sent
 	"RECEIVED",    # the total amount received
@@ -78,6 +79,7 @@ columns = [
 	"PRIVATE",     # true if channel is private
 	"ID",          # the id of the channel
 	# "SCID",      # short channel id (BxTxO formatted)
+	# "NUPD",      # number of channel updates
 ]
 
 [views.transactions]

--- a/config/default.go
+++ b/config/default.go
@@ -35,6 +35,7 @@ columns = [
 	"ALIAS",       # alias of the channel node
 	"GAUGE",       # ascii bar with percent local/capacity
 	"LOCAL",       # the local amount of the channel
+	# "REMOTE",    # the remote amount of the channel
 	"CAP",         # the total capacity of the channel
 	"SENT",        # the total amount sent
 	"RECEIVED",    # the total amount received
@@ -45,6 +46,7 @@ columns = [
 	"PRIVATE",     # true if channel is private
 	"ID",          # the id of the channel
 	# "SCID",      # short channel id (BxTxO formatted)
+	# "NUPD",      # number of channel updates
 ]
 
 [views.transactions]

--- a/ui/views/channels.go
+++ b/ui/views/channels.go
@@ -367,6 +367,19 @@ func NewChannels(cfg *config.View, chans *models.Channels) *Channels {
 					return color.Cyan(opts...)(printer.Sprintf("%12d", c.LocalBalance))
 				},
 			}
+		case "REMOTE":
+			channels.columns[i] = channelsColumn{
+				width: 12,
+				name:  fmt.Sprintf("%12s", columns[i]),
+				sort: func(order models.Order) models.ChannelsSort {
+					return func(c1, c2 *netmodels.Channel) bool {
+						return models.Int64Sort(c1.RemoteBalance, c2.RemoteBalance, order)
+					}
+				},
+				display: func(c *netmodels.Channel, opts ...color.Option) string {
+					return color.Cyan(opts...)(printer.Sprintf("%12d", c.RemoteBalance))
+				},
+			}
 		case "CAP":
 			channels.columns[i] = channelsColumn{
 				width: 12,
@@ -510,6 +523,19 @@ func NewChannels(cfg *config.View, chans *models.Channels) *Channels {
 						return fmt.Sprintf("%-14s", "")
 					}
 					return color.White(opts...)(fmt.Sprintf("%-14s", ToScid(c.ID)))
+				},
+			}
+		case "NUPD":
+			channels.columns[i] = channelsColumn{
+				width: 8,
+				name:  fmt.Sprintf("%-8s", columns[i]),
+				sort: func(order models.Order) models.ChannelsSort {
+					return func(c1, c2 *netmodels.Channel) bool {
+						return models.UInt64Sort(c1.UpdatesCount, c2.UpdatesCount, order)
+					}
+				},
+				display: func(c *netmodels.Channel, opts ...color.Option) string {
+					return color.White(opts...)(printer.Sprintf("%8d", c.UpdatesCount))
 				},
 			}
 		default:


### PR DESCRIPTION
I wondered why isn't there a `remote balance` column, only local and cap, so I added it. It's not just `cap - local`, the calculation is more complex and sometimes it's good to know how much is on the other side. I also added the `number of updates` column, it lets the user estimate the channel popularity and also see what channels are the candidates for reopening to prune the database in case it grows too big. `lnd` saves a distinct revocation transaction for every channel update (which includes any activity in the channel including failed HTLCs) so they might pile up with time and consume significant amount of disk space.