### PR TITLE
#70: Display channel fees

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,11 @@ columns = [
 	"ALIAS",       # alias of the channel node
 	"GAUGE",       # ascii bar with percent local/capacity
 	"LOCAL",       # the local amount of the channel
+	#"BASE_OUT"    # the outgoing base fee of the channel
+	#"RATE_OUT"    # the outgoing fee rate in ppm of the channel
 	# "REMOTE",    # the remote amount of the channel
+	#"BASE_IN"    # the incoming base fee of the channel
+	#"RATE_IN"    # the incoming fee rate in ppm of the channel
 	"CAP",         # the total capacity of the channel
 	"SENT",        # the total amount sent
 	"RECEIVED",    # the total amount received

--- a/ui/views/channels.go
+++ b/ui/views/channels.go
@@ -538,6 +538,58 @@ func NewChannels(cfg *config.View, chans *models.Channels) *Channels {
 					return color.White(opts...)(printer.Sprintf("%8d", c.UpdatesCount))
 				},
 			}
+		case "BASE_OUT":
+			channels.columns[i] = channelsColumn{
+				width: 8,
+				name:  fmt.Sprintf("%-8s", columns[i]),
+				sort: func(order models.Order) models.ChannelsSort {
+					return func(c1, c2 *netmodels.Channel) bool {
+						return models.UInt64Sort(uint64(c1.Policy1.FeeBaseMsat), uint64(c2.Policy1.FeeBaseMsat), order)
+					}
+				},
+				display: func(c *netmodels.Channel, opts ...color.Option) string {
+					return color.White(opts...)(printer.Sprintf("%8d", c.Policy1.FeeBaseMsat))
+				},
+			}
+		case "RATE_OUT":
+			channels.columns[i] = channelsColumn{
+				width: 8,
+				name:  fmt.Sprintf("%-8s", columns[i]),
+				sort: func(order models.Order) models.ChannelsSort {
+					return func(c1, c2 *netmodels.Channel) bool {
+						return models.UInt64Sort(uint64(c1.Policy1.FeeRateMilliMsat), uint64(c2.Policy1.FeeRateMilliMsat), order)
+					}
+				},
+				display: func(c *netmodels.Channel, opts ...color.Option) string {
+					return color.White(opts...)(printer.Sprintf("%8d", c.Policy1.FeeRateMilliMsat))
+				},
+			}
+		case "BASE_IN":
+			channels.columns[i] = channelsColumn{
+				width: 7,
+				name:  fmt.Sprintf("%-7s", columns[i]),
+				sort: func(order models.Order) models.ChannelsSort {
+					return func(c1, c2 *netmodels.Channel) bool {
+						return models.UInt64Sort(uint64(c1.Policy2.FeeBaseMsat), uint64(c2.Policy2.FeeBaseMsat), order)
+					}
+				},
+				display: func(c *netmodels.Channel, opts ...color.Option) string {
+					return color.White(opts...)(printer.Sprintf("%7d", c.Policy2.FeeBaseMsat))
+				},
+			}
+		case "RATE_IN":
+			channels.columns[i] = channelsColumn{
+				width: 7,
+				name:  fmt.Sprintf("%-7s", columns[i]),
+				sort: func(order models.Order) models.ChannelsSort {
+					return func(c1, c2 *netmodels.Channel) bool {
+						return models.UInt64Sort(uint64(c1.Policy2.FeeRateMilliMsat), uint64(c2.Policy2.FeeRateMilliMsat), order)
+					}
+				},
+				display: func(c *netmodels.Channel, opts ...color.Option) string {
+					return color.White(opts...)(printer.Sprintf("%7d", c.Policy2.FeeRateMilliMsat))
+				},
+			}
 		default:
 			channels.columns[i] = channelsColumn{
 				width: 21,


### PR DESCRIPTION
This PR adds columns "BASE OUT", "RATE OUT", "BASE IN" and "RATE IN" for fee rates of the incoming and outgoing channel policy. 
 I am open for suggestions about the naming of inboud/outbound base fee/fee rate so to keep the column space not too crowded.
<img width="1429" alt="image" src="https://user-images.githubusercontent.com/18631614/178513468-f8650326-1d92-4843-bf4c-3996e711e894.png">
