### PR TITLE
Show closed and disabled channels, fix policy order

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -12,6 +12,7 @@ const (
 	TransactionCreated    = "transaction.created"
 	WalletBalanceUpdated  = "wallet.balance.updated"
 	RoutingEventUpdated   = "routing.event.updated"
+	GraphUpdated          = "graph.updated"
 )
 
 type Event struct {

--- a/network/backend/backend.go
+++ b/network/backend/backend.go
@@ -41,4 +41,6 @@ type Backend interface {
 	SubscribeTransactions(context.Context, chan *models.Transaction) error
 
 	SubscribeRoutingEvents(context.Context, chan *models.RoutingEvent) error
+
+	SubscribeGraphEvents(context.Context, chan *models.ChannelEdgeUpdate) error
 }

--- a/network/backend/lnd/lnd.go
+++ b/network/backend/lnd/lnd.go
@@ -412,15 +412,15 @@ func (l Backend) GetChannelInfo(ctx context.Context, channel *models.Channel) er
 
 	t := time.Unix(int64(uint64(resp.LastUpdate)), 0)
 	channel.LastUpdate = &t
-	channel.Policy1 = protoToRoutingPolicy(resp.Node1Policy)
-	channel.Policy2 = protoToRoutingPolicy(resp.Node2Policy)
+	channel.LocalPolicy = protoToRoutingPolicy(resp.Node1Policy)
+	channel.RemotePolicy = protoToRoutingPolicy(resp.Node2Policy)
 
 	info, err := clt.GetInfo(ctx, &lnrpc.GetInfoRequest{})
 	if err != nil {
 		return errors.WithStack(err)
 	}
 	if info != nil && resp.Node1Pub != info.IdentityPubkey {
-		channel.Policy1, channel.Policy2 = channel.Policy2, channel.Policy1
+		channel.LocalPolicy, channel.RemotePolicy = channel.RemotePolicy, channel.LocalPolicy
 	}
 
 	return nil

--- a/network/backend/lnd/lnd.go
+++ b/network/backend/lnd/lnd.go
@@ -371,8 +371,8 @@ func (l Backend) GetChannelInfo(ctx context.Context, channel *models.Channel) er
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	if info != nil {
-		channel.WeFirst = resp.Node1Pub == info.IdentityPubkey
+	if info != nil && resp.Node1Pub != info.IdentityPubkey {
+		channel.Policy1, channel.Policy2 = channel.Policy2, channel.Policy1
 	}
 
 	return nil

--- a/network/backend/lnd/proto.go
+++ b/network/backend/lnd/proto.go
@@ -274,11 +274,11 @@ func nodeProtoToNode(resp *lnrpc.NodeInfo) *models.Node {
 			ID:           c.ChannelId,
 			ChannelPoint: c.ChanPoint,
 			Capacity:     c.Capacity,
-			Policy1:      protoToRoutingPolicy(c.Node1Policy),
-			Policy2:      protoToRoutingPolicy(c.Node2Policy),
+			LocalPolicy:  protoToRoutingPolicy(c.Node1Policy),
+			RemotePolicy: protoToRoutingPolicy(c.Node2Policy),
 		}
 		if c.Node1Pub != resp.Node.PubKey {
-			ch.Policy1, ch.Policy2 = ch.Policy2, ch.Policy1
+			ch.LocalPolicy, ch.RemotePolicy = ch.RemotePolicy, ch.LocalPolicy
 		}
 		channels = append(channels, ch)
 	}

--- a/network/backend/mock/mock.go
+++ b/network/backend/mock/mock.go
@@ -58,7 +58,7 @@ func (b *Backend) SubscribeGraphEvents(ctx context.Context, channel chan *models
 	return nil
 }
 
-func (b *Backend) GetNode(ctx context.Context, pubkey string) (*models.Node, error) {
+func (b *Backend) GetNode(ctx context.Context, pubkey string, includeChannels bool) (*models.Node, error) {
 	return &models.Node{}, nil
 }
 

--- a/network/backend/mock/mock.go
+++ b/network/backend/mock/mock.go
@@ -54,7 +54,11 @@ func (b *Backend) SubscribeRoutingEvents(ctx context.Context, channel chan *mode
 	return nil
 }
 
-func (b *Backend) GetNode(ctx context.Context, pubkey string, includeChannels bool) (*models.Node, error) {
+func (b *Backend) SubscribeGraphEvents(ctx context.Context, channel chan *models.ChannelEdgeUpdate) error {
+	return nil
+}
+
+func (b *Backend) GetNode(ctx context.Context, pubkey string) (*models.Node, error) {
 	return &models.Node{}, nil
 }
 

--- a/network/models/channel.go
+++ b/network/models/channel.go
@@ -49,7 +49,6 @@ type Channel struct {
 	PendingHTLC         []*HTLC
 	LastUpdate          *time.Time
 	Node                *Node
-	WeFirst             bool
 	Policy1             *RoutingPolicy
 	Policy2             *RoutingPolicy
 }

--- a/network/models/channel.go
+++ b/network/models/channel.go
@@ -90,6 +90,9 @@ func (m Channel) ShortAlias() (alias string, forced bool) {
 type ChannelUpdate struct {
 }
 
+type ChannelEdgeUpdate struct {
+	ChanPoints []string
+}
 type RoutingPolicy struct {
 	TimeLockDelta    uint32
 	MinHtlc          int64

--- a/network/models/channel.go
+++ b/network/models/channel.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"strings"
 	"time"
 
 	"github.com/edouardparis/lntop/logging"
@@ -13,6 +14,7 @@ const (
 	ChannelClosing
 	ChannelForceClosing
 	ChannelWaitingClose
+	ChannelClosed
 )
 
 type ChannelsBalance struct {
@@ -78,7 +80,7 @@ func (m Channel) ShortAlias() (alias string, forced bool) {
 	} else if m.Node == nil || m.Node.Alias == "" {
 		alias = m.RemotePubKey[:24]
 	} else {
-		alias = m.Node.Alias
+		alias = strings.ReplaceAll(m.Node.Alias, "\ufe0f", "")
 	}
 	if len(alias) > 25 {
 		alias = alias[:24]

--- a/network/models/channel.go
+++ b/network/models/channel.go
@@ -49,8 +49,8 @@ type Channel struct {
 	PendingHTLC         []*HTLC
 	LastUpdate          *time.Time
 	Node                *Node
-	Policy1             *RoutingPolicy
-	Policy2             *RoutingPolicy
+	LocalPolicy         *RoutingPolicy
+	RemotePolicy        *RoutingPolicy
 }
 
 func (m Channel) MarshalLogObject(enc logging.ObjectEncoder) error {

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -117,6 +117,35 @@ func (p *PubSub) routingUpdates(ctx context.Context, sub chan *events.Event) {
 	}()
 }
 
+func (p *PubSub) graphUpdates(ctx context.Context, sub chan *events.Event) {
+	p.wg.Add(3)
+	graphUpdates := make(chan *models.ChannelEdgeUpdate)
+	ctx, cancel := context.WithCancel(ctx)
+
+	go func() {
+		for gu := range graphUpdates {
+			p.logger.Debug("receive graph update")
+			sub <- events.NewWithData(events.GraphUpdated, gu)
+		}
+		p.wg.Done()
+	}()
+
+	go func() {
+		err := p.network.SubscribeGraphEvents(ctx, graphUpdates)
+		if err != nil {
+			p.logger.Error("SubscribeGraphEvents returned an error", logging.Error(err))
+		}
+		p.wg.Done()
+	}()
+
+	go func() {
+		<-p.stop
+		cancel()
+		close(graphUpdates)
+		p.wg.Done()
+	}()
+}
+
 func (p *PubSub) channels(ctx context.Context, sub chan *events.Event) {
 	p.wg.Add(3)
 	channels := make(chan *models.ChannelUpdate)
@@ -159,6 +188,7 @@ func (p *PubSub) Run(ctx context.Context, sub chan *events.Event) {
 	p.transactions(ctx, sub)
 	p.routingUpdates(ctx, sub)
 	p.channels(ctx, sub)
+	p.graphUpdates(ctx, sub)
 	p.ticker(ctx, sub,
 		withTickerInfo(),
 		withTickerChannelsBalance(),

--- a/ui/controller.go
+++ b/ui/controller.go
@@ -179,6 +179,8 @@ func (c *controller) Listen(ctx context.Context, g *gocui.Gui, sub chan *events.
 			refresh(c.models.RefreshInfo)
 		case events.RoutingEventUpdated:
 			refresh(c.models.RefreshRouting(event.Data))
+		case events.GraphUpdated:
+			refresh(c.models.RefreshPolicies(event.Data))
 		}
 	}
 }

--- a/ui/models/channels.go
+++ b/ui/models/channels.go
@@ -109,12 +109,12 @@ func (c *Channels) Update(newChannel *models.Channel) {
 		oldChannel.LastUpdate = newChannel.LastUpdate
 	}
 
-	if newChannel.Policy1 != nil {
-		oldChannel.Policy1 = newChannel.Policy1
+	if newChannel.LocalPolicy != nil {
+		oldChannel.LocalPolicy = newChannel.LocalPolicy
 	}
 
-	if newChannel.Policy2 != nil {
-		oldChannel.Policy2 = newChannel.Policy2
+	if newChannel.RemotePolicy != nil {
+		oldChannel.RemotePolicy = newChannel.RemotePolicy
 	}
 }
 

--- a/ui/models/models.go
+++ b/ui/models/models.go
@@ -52,14 +52,16 @@ func (m *Models) RefreshChannels(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	index := map[string]*models.Channel{}
 	for i := range channels {
+		index[channels[i].ChannelPoint] = channels[i]
 		if !m.Channels.Contains(channels[i]) {
 			m.Channels.Add(channels[i])
 		}
 		channel := m.Channels.GetByChanPoint(channels[i].ChannelPoint)
 		if channel != nil &&
 			(channel.UpdatesCount < channels[i].UpdatesCount ||
-				channel.LastUpdate == nil) {
+				channel.LastUpdate == nil || channel.Policy1 == nil || channel.Policy2 == nil) {
 			err := m.network.GetChannelInfo(ctx, channels[i])
 			if err != nil {
 				return err
@@ -76,6 +78,11 @@ func (m *Models) RefreshChannels(ctx context.Context) error {
 		}
 
 		m.Channels.Update(channels[i])
+	}
+	for _, c := range m.Channels.List() {
+		if _, ok := index[c.ChannelPoint]; !ok {
+			c.Status = models.ChannelClosed
+		}
 	}
 	return nil
 }

--- a/ui/models/models.go
+++ b/ui/models/models.go
@@ -144,6 +144,22 @@ func (m *Models) RefreshRouting(update interface{}) func(context.Context) error 
 	})
 }
 
+func (m *Models) RefreshPolicies(update interface{}) func(context.Context) error {
+	return func(ctx context.Context) error {
+		for _, chanpoint := range update.(*models.ChannelEdgeUpdate).ChanPoints {
+			if m.Channels.Contains(&models.Channel{ChannelPoint: chanpoint}) {
+				m.logger.Debug("updating channel", logging.String("chanpoint", chanpoint))
+				channel := m.Channels.GetByChanPoint(chanpoint)
+				err := m.network.GetChannelInfo(ctx, channel)
+				if err != nil {
+					m.logger.Error("error updating channel info", logging.Error(err))
+				}
+			}
+		}
+		return nil
+	}
+}
+
 func (m *Models) RefreshCurrentNode(ctx context.Context) (err error) {
 	cur := m.Channels.Current()
 	if cur != nil {

--- a/ui/models/models.go
+++ b/ui/models/models.go
@@ -61,7 +61,7 @@ func (m *Models) RefreshChannels(ctx context.Context) error {
 		channel := m.Channels.GetByChanPoint(channels[i].ChannelPoint)
 		if channel != nil &&
 			(channel.UpdatesCount < channels[i].UpdatesCount ||
-				channel.LastUpdate == nil || channel.Policy1 == nil || channel.Policy2 == nil) {
+				channel.LastUpdate == nil || channel.LocalPolicy == nil || channel.RemotePolicy == nil) {
 			err := m.network.GetChannelInfo(ctx, channels[i])
 			if err != nil {
 				return err

--- a/ui/views/channel.go
+++ b/ui/views/channel.go
@@ -218,10 +218,10 @@ func (c *Channel) display() {
 			disabledOut := 0
 			disabledIn := 0
 			for _, ch := range c.channels.CurrentNode.Channels {
-				if ch.Policy1 != nil && ch.Policy1.Disabled {
+				if ch.LocalPolicy != nil && ch.LocalPolicy.Disabled {
 					disabledOut++
 				}
-				if ch.Policy2 != nil && ch.Policy2.Disabled {
+				if ch.RemotePolicy != nil && ch.RemotePolicy.Disabled {
 					disabledIn++
 				}
 			}
@@ -230,12 +230,12 @@ func (c *Channel) display() {
 		}
 	}
 
-	if channel.Policy1 != nil {
-		printPolicy(v, p, channel.Policy1, true)
+	if channel.LocalPolicy != nil {
+		printPolicy(v, p, channel.LocalPolicy, true)
 	}
 
-	if channel.Policy2 != nil {
-		printPolicy(v, p, channel.Policy2, false)
+	if channel.RemotePolicy != nil {
+		printPolicy(v, p, channel.RemotePolicy, false)
 	}
 
 	if len(channel.PendingHTLC) > 0 {

--- a/ui/views/channel.go
+++ b/ui/views/channel.go
@@ -230,17 +230,14 @@ func (c *Channel) display() {
 		}
 	}
 
-	if channel.Policy1 != nil && channel.WeFirst {
+	if channel.Policy1 != nil {
 		printPolicy(v, p, channel.Policy1, true)
 	}
 
 	if channel.Policy2 != nil {
-		printPolicy(v, p, channel.Policy2, !channel.WeFirst)
+		printPolicy(v, p, channel.Policy2, false)
 	}
 
-	if channel.Policy1 != nil && !channel.WeFirst {
-		printPolicy(v, p, channel.Policy1, false)
-	}
 	if len(channel.PendingHTLC) > 0 {
 		fmt.Fprintln(v)
 		fmt.Fprintln(v, green(" [ Pending HTLCs ]"))

--- a/ui/views/channels.go
+++ b/ui/views/channels.go
@@ -666,6 +666,8 @@ func status(c *netmodels.Channel, opts ...color.Option) string {
 		return color.Yellow(opts...)(fmt.Sprintf("%-13s", "force closing"))
 	case netmodels.ChannelWaitingClose:
 		return color.Yellow(opts...)(fmt.Sprintf("%-13s", "waiting close"))
+	case netmodels.ChannelClosed:
+		return color.Red(opts...)(fmt.Sprintf("%-13s", "closed"))
 	}
 	return ""
 }

--- a/ui/views/channels.go
+++ b/ui/views/channels.go
@@ -546,19 +546,19 @@ func NewChannels(cfg *config.View, chans *models.Channels) *Channels {
 					return func(c1, c2 *netmodels.Channel) bool {
 						var c1f uint64
 						var c2f uint64
-						if c1.Policy1 != nil {
-							c1f = uint64(c1.Policy1.FeeBaseMsat)
+						if c1.LocalPolicy != nil {
+							c1f = uint64(c1.LocalPolicy.FeeBaseMsat)
 						}
-						if c2.Policy1 != nil {
-							c2f = uint64(c2.Policy1.FeeBaseMsat)
+						if c2.LocalPolicy != nil {
+							c2f = uint64(c2.LocalPolicy.FeeBaseMsat)
 						}
 						return models.UInt64Sort(c1f, c2f, order)
 					}
 				},
 				display: func(c *netmodels.Channel, opts ...color.Option) string {
 					var val int64
-					if c.Policy1 != nil {
-						val = c.Policy1.FeeBaseMsat
+					if c.LocalPolicy != nil {
+						val = c.LocalPolicy.FeeBaseMsat
 					}
 					return color.White(opts...)(printer.Sprintf("%8d", val))
 				},
@@ -571,19 +571,19 @@ func NewChannels(cfg *config.View, chans *models.Channels) *Channels {
 					return func(c1, c2 *netmodels.Channel) bool {
 						var c1f uint64
 						var c2f uint64
-						if c1.Policy1 != nil {
-							c1f = uint64(c1.Policy1.FeeRateMilliMsat)
+						if c1.LocalPolicy != nil {
+							c1f = uint64(c1.LocalPolicy.FeeRateMilliMsat)
 						}
-						if c2.Policy1 != nil {
-							c2f = uint64(c2.Policy1.FeeRateMilliMsat)
+						if c2.LocalPolicy != nil {
+							c2f = uint64(c2.LocalPolicy.FeeRateMilliMsat)
 						}
 						return models.UInt64Sort(c1f, c2f, order)
 					}
 				},
 				display: func(c *netmodels.Channel, opts ...color.Option) string {
 					var val int64
-					if c.Policy1 != nil {
-						val = c.Policy1.FeeRateMilliMsat
+					if c.LocalPolicy != nil {
+						val = c.LocalPolicy.FeeRateMilliMsat
 					}
 					return color.White(opts...)(printer.Sprintf("%8d", val))
 				},
@@ -596,19 +596,19 @@ func NewChannels(cfg *config.View, chans *models.Channels) *Channels {
 					return func(c1, c2 *netmodels.Channel) bool {
 						var c1f uint64
 						var c2f uint64
-						if c1.Policy2 != nil {
-							c1f = uint64(c1.Policy2.FeeBaseMsat)
+						if c1.RemotePolicy != nil {
+							c1f = uint64(c1.RemotePolicy.FeeBaseMsat)
 						}
-						if c2.Policy2 != nil {
-							c2f = uint64(c2.Policy2.FeeBaseMsat)
+						if c2.RemotePolicy != nil {
+							c2f = uint64(c2.RemotePolicy.FeeBaseMsat)
 						}
 						return models.UInt64Sort(c1f, c2f, order)
 					}
 				},
 				display: func(c *netmodels.Channel, opts ...color.Option) string {
 					var val int64
-					if c.Policy2 != nil {
-						val = c.Policy2.FeeBaseMsat
+					if c.RemotePolicy != nil {
+						val = c.RemotePolicy.FeeBaseMsat
 					}
 					return color.White(opts...)(printer.Sprintf("%7d", val))
 				},
@@ -621,19 +621,19 @@ func NewChannels(cfg *config.View, chans *models.Channels) *Channels {
 					return func(c1, c2 *netmodels.Channel) bool {
 						var c1f uint64
 						var c2f uint64
-						if c1.Policy2 != nil {
-							c1f = uint64(c1.Policy2.FeeRateMilliMsat)
+						if c1.RemotePolicy != nil {
+							c1f = uint64(c1.RemotePolicy.FeeRateMilliMsat)
 						}
-						if c2.Policy2 != nil {
-							c2f = uint64(c2.Policy2.FeeRateMilliMsat)
+						if c2.RemotePolicy != nil {
+							c2f = uint64(c2.RemotePolicy.FeeRateMilliMsat)
 						}
 						return models.UInt64Sort(c1f, c2f, order)
 					}
 				},
 				display: func(c *netmodels.Channel, opts ...color.Option) string {
 					var val int64
-					if c.Policy2 != nil {
-						val = c.Policy2.FeeRateMilliMsat
+					if c.RemotePolicy != nil {
+						val = c.RemotePolicy.FeeRateMilliMsat
 					}
 					return color.White(opts...)(printer.Sprintf("%7d", val))
 				},
@@ -655,10 +655,10 @@ func NewChannels(cfg *config.View, chans *models.Channels) *Channels {
 func channelDisabled(c *netmodels.Channel, opts ...color.Option) string {
 	outgoing := false
 	incoming := false
-	if c.Policy1 != nil && c.Policy1.Disabled {
+	if c.LocalPolicy != nil && c.LocalPolicy.Disabled {
 		outgoing = true
 	}
-	if c.Policy2 != nil && c.Policy2.Disabled {
+	if c.RemotePolicy != nil && c.RemotePolicy.Disabled {
 		incoming = true
 	}
 	result := ""

--- a/ui/views/channels.go
+++ b/ui/views/channels.go
@@ -652,12 +652,40 @@ func NewChannels(cfg *config.View, chans *models.Channels) *Channels {
 	return channels
 }
 
+func channelDisabled(c *netmodels.Channel, opts ...color.Option) string {
+	outgoing := false
+	incoming := false
+	if c.Policy1 != nil && c.Policy1.Disabled {
+		outgoing = true
+	}
+	if c.Policy2 != nil && c.Policy2.Disabled {
+		incoming = true
+	}
+	result := ""
+	if incoming && outgoing {
+		result = "⇅"
+	} else if incoming {
+		result = "⇊"
+	} else if outgoing {
+		result = "⇈"
+	}
+	if result == "" {
+		return result
+	}
+	return color.Red(opts...)(fmt.Sprintf("%-4s", result))
+}
+
 func status(c *netmodels.Channel, opts ...color.Option) string {
+	disabled := channelDisabled(c, opts...)
+	format := "%-13s"
+	if disabled != "" {
+		format = "%-9s"
+	}
 	switch c.Status {
 	case netmodels.ChannelActive:
-		return color.Green(opts...)(fmt.Sprintf("%-13s", "active"))
+		return color.Green(opts...)(fmt.Sprintf(format, "active ")) + disabled
 	case netmodels.ChannelInactive:
-		return color.Red(opts...)(fmt.Sprintf("%-13s", "inactive"))
+		return color.Red(opts...)(fmt.Sprintf(format, "inactive ")) + disabled
 	case netmodels.ChannelOpening:
 		return color.Yellow(opts...)(fmt.Sprintf("%-13s", "opening"))
 	case netmodels.ChannelClosing:


### PR DESCRIPTION
This PR fixes a couple of annoyances:
1. New channels displayed incoming/outgoing policies wrong due to outdated information. Now these policies are fetched on every channel update if any of them is `nil`. This should only happen when the channel is very new and the policy information isn't well propagated. It won't result in a big gRPC request inefficiency.
2. Closed (fully resolved) channels are now marked as such explicitly. It's possible to delete these channels when they're closed but it might be confusing so I decided to add a new channel status `closed` instead and mark all channels that aren't present in the `listchannels` result as closed. Additionally I added channel status subscription, there was such a function already but its implementation was mostly commented out so I finished it. For now it simply triggers channel update when any channel is reported as fully resolved. To remove the closed channels from the list currently the user should restart the program. Maybe in the future it would be worth it to add a special key bind to fully refresh the channel information.
3. Disabled channels are marked with red arrows in the status column. ⇊ — disabled to us, ⇈ — disabled from us, ⇅ — disabled in both directions. Characters I picked are debatable of course, let me know if you like them or not and what to use.
![2022-09-03_00-41-36](https://user-images.githubusercontent.com/184066/188239155-20a9589d-5485-4bb8-9f5e-971e1bd25625.png)

There's also one more event subscription added, to graph events. Currently it only retrieves updated chan points and updates policies for corresponding channels. The rest of event information isn't used.

PS: there's also a very small alias cleanup that removes `\ufe0f` character because it breaks the UI. When the cursor is on that line all columns after the alias are shifted by 1 character to the left and some positions aren't redrawn after that. I think there are more such breaking characters but I've only encountered one in [this node alias](https://amboss.space/node/03423790614f023e3c0cdaa654a3578e919947e4c3a14bf5044e7c787ebd11af1a).
PPS: I think fixing the underlying TUI library is a better solution but it might be a much harder task. I tried upgrading to the [modern fork of gocui](https://github.com/awesome-gocui/gocui) and the UI was in shambles, the columns were not lined up at all. Probably it needs more efforts to fix. 
The character I remove simply switches the previous symbol rendering from text-like to emoji-like (colored and shiny), cool thing to have but not at the cost of broken UI.