### PR TITLE
Add pretty amount formatting

### DIFF
--- a/network/backend/lnd/proto.go
+++ b/network/backend/lnd/proto.go
@@ -286,6 +286,7 @@ func protoToRoutingPolicy(resp *lnrpc.RoutingPolicy) *models.RoutingPolicy {
 	return &models.RoutingPolicy{
 		TimeLockDelta:    resp.TimeLockDelta,
 		MinHtlc:          resp.MinHtlc,
+		MaxHtlc:          resp.MaxHtlcMsat,
 		FeeBaseMsat:      resp.FeeBaseMsat,
 		FeeRateMilliMsat: resp.FeeRateMilliMsat,
 		Disabled:         resp.Disabled,

--- a/network/models/channel.go
+++ b/network/models/channel.go
@@ -92,6 +92,7 @@ type ChannelUpdate struct {
 type RoutingPolicy struct {
 	TimeLockDelta    uint32
 	MinHtlc          int64
+	MaxHtlc          uint64
 	FeeBaseMsat      int64
 	FeeRateMilliMsat int64
 	Disabled         bool

--- a/ui/views/channel.go
+++ b/ui/views/channel.go
@@ -141,6 +141,26 @@ func printPolicy(v *gocui.View, p *message.Printer, policy *netModels.RoutingPol
 		cyan(" Fee rate milli msat:"), policy.FeeRateMilliMsat)
 }
 
+func formatAmount(amt int64) string {
+	btc := amt / 1e8
+	ms := amt % 1e8 / 1e6
+	ts := amt % 1e6 / 1e3
+	s := amt % 1e3
+	if btc > 0 {
+		return fmt.Sprintf("%d.%02d,%03d,%03d", btc, ms, ts, s)
+	}
+	if ms > 0 {
+		return fmt.Sprintf("%d,%03d,%03d", ms, ts, s)
+	}
+	if ts > 0 {
+		return fmt.Sprintf("%d,%03d", ts, s)
+	}
+	if s >= 0 {
+		return fmt.Sprintf("%d", s)
+	}
+	return fmt.Sprintf("error: %d", amt)
+}
+
 func (c *Channel) display() {
 	p := message.NewPrinter(language.English)
 	v := c.view
@@ -153,12 +173,12 @@ func (c *Channel) display() {
 		cyan("         Status:"), status(channel))
 	fmt.Fprintf(v, "%s %d (%s)\n",
 		cyan("             ID:"), channel.ID, ToScid(channel.ID))
-	fmt.Fprintf(v, "%s %d\n",
-		cyan("       Capacity:"), channel.Capacity)
-	fmt.Fprintf(v, "%s %d\n",
-		cyan("  Local Balance:"), channel.LocalBalance)
-	fmt.Fprintf(v, "%s %d\n",
-		cyan(" Remote Balance:"), channel.RemoteBalance)
+	fmt.Fprintf(v, "%s %s\n",
+		cyan("       Capacity:"), formatAmount(channel.Capacity))
+	fmt.Fprintf(v, "%s %s\n",
+		cyan("  Local Balance:"), formatAmount(channel.LocalBalance))
+	fmt.Fprintf(v, "%s %s\n",
+		cyan(" Remote Balance:"), formatAmount(channel.RemoteBalance))
 	fmt.Fprintf(v, "%s %s\n",
 		cyan("  Channel Point:"), channel.ChannelPoint)
 	fmt.Fprintln(v, "")
@@ -173,8 +193,8 @@ func (c *Channel) display() {
 		}
 		fmt.Fprintf(v, "%s %s\n",
 			cyan("          Alias:"), alias)
-		fmt.Fprintf(v, "%s %d\n",
-			cyan(" Total Capacity:"), channel.Node.TotalCapacity)
+		fmt.Fprintf(v, "%s %s\n",
+			cyan(" Total Capacity:"), formatAmount(channel.Node.TotalCapacity))
 		fmt.Fprintf(v, "%s %d\n",
 			cyan(" Total Channels:"), channel.Node.NumChannels)
 	}
@@ -196,8 +216,8 @@ func (c *Channel) display() {
 		for _, htlc := range channel.PendingHTLC {
 			fmt.Fprintf(v, "%s %t\n",
 				cyan("   Incoming:"), htlc.Incoming)
-			fmt.Fprintf(v, "%s %d\n",
-				cyan("     Amount:"), htlc.Amount)
+			fmt.Fprintf(v, "%s %s\n",
+				cyan("     Amount:"), formatAmount(htlc.Amount))
 			fmt.Fprintf(v, "%s %d\n",
 				cyan(" Expiration:"), htlc.ExpirationHeight)
 			fmt.Fprintln(v)

--- a/ui/views/channel.go
+++ b/ui/views/channel.go
@@ -133,8 +133,10 @@ func printPolicy(v *gocui.View, p *message.Printer, policy *netModels.RoutingPol
 	}
 	fmt.Fprintf(v, "%s %d\n",
 		cyan("     Time lock delta:"), policy.TimeLockDelta)
-	fmt.Fprintf(v, "%s %d\n",
-		cyan("            Min htlc:"), policy.MinHtlc)
+	fmt.Fprintf(v, "%s %s\n",
+		cyan("     Min htlc (msat):"), formatAmount(policy.MinHtlc))
+	fmt.Fprintf(v, "%s %s\n",
+		cyan("      Max htlc (sat):"), formatAmount(int64(policy.MaxHtlc/1000)))
 	fmt.Fprintf(v, "%s %d\n",
 		cyan("       Fee base msat:"), policy.FeeBaseMsat)
 	fmt.Fprintf(v, "%s %d\n",

--- a/ui/views/channel.go
+++ b/ui/views/channel.go
@@ -137,8 +137,8 @@ func printPolicy(v *gocui.View, p *message.Printer, policy *netModels.RoutingPol
 		cyan("     Min htlc (msat):"), formatAmount(policy.MinHtlc))
 	fmt.Fprintf(v, "%s %s\n",
 		cyan("      Max htlc (sat):"), formatAmount(int64(policy.MaxHtlc/1000)))
-	fmt.Fprintf(v, "%s %d\n",
-		cyan("       Fee base msat:"), policy.FeeBaseMsat)
+	fmt.Fprintf(v, "%s %s\n",
+		cyan("       Fee base msat:"), formatAmount(policy.FeeBaseMsat))
 	fmt.Fprintf(v, "%s %d\n",
 		cyan(" Fee rate milli msat:"), policy.FeeRateMilliMsat)
 }

--- a/ui/views/summary.go
+++ b/ui/views/summary.go
@@ -58,11 +58,11 @@ func (s *Summary) display() {
 	cyan := color.Cyan()
 	red := color.Red()
 	fmt.Fprintln(s.left, green("[ Channels ]"))
-	fmt.Fprintln(s.left, p.Sprintf("%s %d (%s|%s)",
+	fmt.Fprintln(s.left, p.Sprintf("%s %s (%s|%s)",
 		cyan("balance:"),
-		s.channelsBalance.Balance+s.channelsBalance.PendingOpenBalance,
-		green(p.Sprintf("%d", s.channelsBalance.Balance)),
-		yellow(p.Sprintf("%d", s.channelsBalance.PendingOpenBalance)),
+		formatAmount(s.channelsBalance.Balance+s.channelsBalance.PendingOpenBalance),
+		green(p.Sprintf("%s", formatAmount(s.channelsBalance.Balance))),
+		yellow(p.Sprintf("%s", formatAmount(s.channelsBalance.PendingOpenBalance))),
 	))
 	fmt.Fprintln(s.left, fmt.Sprintf("%s %d %s %d %s %d %s",
 		cyan("state  :"),
@@ -77,11 +77,11 @@ func (s *Summary) display() {
 
 	s.right.Clear()
 	fmt.Fprintln(s.right, green("[ Wallet ]"))
-	fmt.Fprintln(s.right, p.Sprintf("%s %d (%s|%s)",
+	fmt.Fprintln(s.right, p.Sprintf("%s %s (%s|%s)",
 		cyan("balance:"),
-		s.walletBalance.TotalBalance,
-		green(p.Sprintf("%d", s.walletBalance.ConfirmedBalance)),
-		yellow(p.Sprintf("%d", s.walletBalance.UnconfirmedBalance)),
+		formatAmount(s.walletBalance.TotalBalance),
+		green(p.Sprintf("%s", formatAmount(s.walletBalance.ConfirmedBalance))),
+		yellow(p.Sprintf("%s", formatAmount(s.walletBalance.UnconfirmedBalance))),
 	))
 }
 


### PR DESCRIPTION
Amounts are hard to read without separators and in Bitcoin case the usual groups of three digits can be confusing because 1 BTC is 10e8 sats. Instead I implemented a better format proposed by [satcomma](https://bitcoin.design/guide/designing-products/units-and-symbols/#satcomma). It's not exactly like the link describes because I replaced spaces with commas to make it look consistent with the main screen. Most amounts like channels and HTLCs don't need the BTC point because they're usually much smaller than 1 BTC so commas are fine. Total node capacities are usually greater than 1 BTC so it's appropriate there. I currently didn't patch the other screens that show amounts because of this reason.
![2022-09-06_18-12-01](https://user-images.githubusercontent.com/184066/188672909-19e97055-dfd6-43dc-b709-07a37a059862.png)
