### PR TITLE
Show disabled channel count for node

### DIFF
--- a/network/backend/backend.go
+++ b/network/backend/backend.go
@@ -18,7 +18,7 @@ type Backend interface {
 
 	Info(context.Context) (*models.Info, error)
 
-	GetNode(context.Context, string) (*models.Node, error)
+	GetNode(context.Context, string, bool) (*models.Node, error)
 
 	GetWalletBalance(context.Context) (*models.WalletBalance, error)
 

--- a/network/backend/lnd/lnd.go
+++ b/network/backend/lnd/lnd.go
@@ -365,7 +365,7 @@ func (l Backend) GetChannelInfo(ctx context.Context, channel *models.Channel) er
 	return nil
 }
 
-func (l Backend) GetNode(ctx context.Context, pubkey string) (*models.Node, error) {
+func (l Backend) GetNode(ctx context.Context, pubkey string, includeChannels bool) (*models.Node, error) {
 	l.logger.Debug("GetNode")
 
 	clt, err := l.Client(ctx)
@@ -374,7 +374,7 @@ func (l Backend) GetNode(ctx context.Context, pubkey string) (*models.Node, erro
 	}
 	defer clt.Close()
 
-	req := &lnrpc.NodeInfoRequest{PubKey: pubkey}
+	req := &lnrpc.NodeInfoRequest{PubKey: pubkey, IncludeChannels: includeChannels}
 	resp, err := clt.GetNodeInfo(ctx, req)
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/network/backend/lnd/proto.go
+++ b/network/backend/lnd/proto.go
@@ -268,6 +268,20 @@ func nodeProtoToNode(resp *lnrpc.NodeInfo) *models.Node {
 			Addr:    resp.Node.Addresses[i].Addr,
 		}
 	}
+	channels := []*models.Channel{}
+	for _, c := range resp.Channels {
+		ch := &models.Channel{
+			ID:           c.ChannelId,
+			ChannelPoint: c.ChanPoint,
+			Capacity:     c.Capacity,
+			Policy1:      protoToRoutingPolicy(c.Node1Policy),
+			Policy2:      protoToRoutingPolicy(c.Node2Policy),
+		}
+		if c.Node1Pub != resp.Node.PubKey {
+			ch.Policy1, ch.Policy2 = ch.Policy2, ch.Policy1
+		}
+		channels = append(channels, ch)
+	}
 
 	return &models.Node{
 		NumChannels:   resp.NumChannels,
@@ -276,6 +290,7 @@ func nodeProtoToNode(resp *lnrpc.NodeInfo) *models.Node {
 		PubKey:        resp.Node.PubKey,
 		Alias:         resp.Node.Alias,
 		Addresses:     addresses,
+		Channels:      channels,
 	}
 }
 

--- a/network/backend/mock/mock.go
+++ b/network/backend/mock/mock.go
@@ -54,7 +54,7 @@ func (b *Backend) SubscribeRoutingEvents(ctx context.Context, channel chan *mode
 	return nil
 }
 
-func (b *Backend) GetNode(ctx context.Context, pubkey string) (*models.Node, error) {
+func (b *Backend) GetNode(ctx context.Context, pubkey string, includeChannels bool) (*models.Node, error) {
 	return &models.Node{}, nil
 }
 

--- a/network/models/node.go
+++ b/network/models/node.go
@@ -10,6 +10,7 @@ type Node struct {
 	Alias         string
 	ForcedAlias   string
 	Addresses     []*NodeAddress
+	Channels      []*Channel
 }
 
 type NodeAddress struct {

--- a/ui/controller.go
+++ b/ui/controller.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"context"
+	"time"
 
 	"github.com/jroimartin/gocui"
 
@@ -240,6 +241,9 @@ func (c *controller) OnEnter(g *gocui.Gui, v *gocui.View) error {
 	case views.CHANNELS:
 		index := c.views.Channels.Index()
 		c.models.Channels.SetCurrent(index)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
+		defer cancel()
+		c.models.RefreshCurrentNode(ctx)
 		c.views.Main = c.views.Channel
 		return ToggleView(g, view, c.views.Channels)
 
@@ -299,6 +303,16 @@ func (c *controller) OnEnter(g *gocui.Gui, v *gocui.View) error {
 		c.views.Main = c.views.Transactions
 		return ToggleView(g, view, c.views.Transactions)
 	}
+	return nil
+}
+
+func (c *controller) NodeInfo(g *gocui.Gui, v *gocui.View) error {
+	if v.Name() != views.CHANNEL {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	c.models.RefreshCurrentNode(ctx)
 	return nil
 }
 

--- a/ui/keybindings.go
+++ b/ui/keybindings.go
@@ -120,5 +120,10 @@ func setKeyBinding(c *controller, g *gocui.Gui) error {
 		return err
 	}
 
+	err = g.SetKeybinding("", 'c', gocui.ModNone, c.NodeInfo)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/ui/models/channels.go
+++ b/ui/models/channels.go
@@ -10,11 +10,12 @@ import (
 type ChannelsSort func(*models.Channel, *models.Channel) bool
 
 type Channels struct {
-	current *models.Channel
-	index   map[string]*models.Channel
-	list    []*models.Channel
-	sort    ChannelsSort
-	mu      sync.RWMutex
+	current     *models.Channel
+	index       map[string]*models.Channel
+	list        []*models.Channel
+	sort        ChannelsSort
+	mu          sync.RWMutex
+	CurrentNode *models.Node
 }
 
 func (c *Channels) List() []*models.Channel {

--- a/ui/models/models.go
+++ b/ui/models/models.go
@@ -67,7 +67,7 @@ func (m *Models) RefreshChannels(ctx context.Context) error {
 
 			if channels[i].Node == nil {
 				channels[i].Node, err = m.network.GetNode(ctx,
-					channels[i].RemotePubKey)
+					channels[i].RemotePubKey, false)
 				if err != nil {
 					m.logger.Debug("refreshChannels: cannot find Node",
 						logging.String("pubkey", channels[i].RemotePubKey))
@@ -135,4 +135,12 @@ func (m *Models) RefreshRouting(update interface{}) func(context.Context) error 
 		}
 		return nil
 	})
+}
+
+func (m *Models) RefreshCurrentNode(ctx context.Context) (err error) {
+	cur := m.Channels.Current()
+	if cur != nil {
+		m.Channels.CurrentNode, err = m.network.GetNode(ctx, cur.RemotePubKey, true)
+	}
+	return
 }

--- a/ui/views/channel.go
+++ b/ui/views/channel.go
@@ -174,7 +174,7 @@ func formatDisabledCount(cnt int, total uint32) string {
 	} else {
 		disabledStr = fmt.Sprintf("%4d", cnt)
 	}
-	return fmt.Sprintf("%s / %d", disabledStr, total)
+	return fmt.Sprintf("%s / %d (%d%%)", disabledStr, total, perc)
 }
 
 func (c *Channel) display() {


### PR DESCRIPTION
![2022-09-07_20-37-33](https://user-images.githubusercontent.com/184066/188943630-6cd7c0f4-c728-4e7f-be70-7aefcb6e7f25.png)
![2022-09-07_20-37-23](https://user-images.githubusercontent.com/184066/188943633-34bcd58c-3864-4bd8-bb29-d04fc1aef7fc.png)

This PR adds the ability to see how many channels are disabled to and from your peer. It's useful to find out if the peer has a big outage or if it's just your connectivity. Basically "down for everyone or just me?". The number of disabled channels is highlighted with bold yellow if the percentage of disabled channels is between 25 and 50, and bold red if it's 50% or more.

While testing on RPi I noticed that this feature adds some inconvenience when I open a channel to a big node like ACINQ, it takes too much time to retrieve and process all those channels (around 1-1.5 seconds but still). Since this feature isn't very essential and to not degrade the overall experience I added some context magic. Now the disabled channels are only shown if this request takes less than 100 ms, otherwise the user can issue it manually by pressing the <kbd>C</kbd> key. In the latter case the timeout for the operation is 5 seconds which should be more than enough.

The screenshots above are from my develop branch that includes other patches I proposed so they look slightly different than the current master.