### PR TITLE
#84: Fix fee order

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ columns = [
 	"ALIAS",       # alias of the channel node
 	"GAUGE",       # ascii bar with percent local/capacity
 	"LOCAL",       # the local amount of the channel
+	"REMOTE",      # the remote amount of the channel
 	#"BASE_OUT"    # the outgoing base fee of the channel
 	#"RATE_OUT"    # the outgoing fee rate in ppm of the channel
-	# "REMOTE",    # the remote amount of the channel
-	#"BASE_IN"    # the incoming base fee of the channel
-	#"RATE_IN"    # the incoming fee rate in ppm of the channel
+	#"BASE_IN"     # the incoming base fee of the channel
+	#"RATE_IN"     # the incoming fee rate in ppm of the channel
 	"CAP",         # the total capacity of the channel
 	"SENT",        # the total amount sent
 	"RECEIVED",    # the total amount received

--- a/network/backend/lnd/lnd.go
+++ b/network/backend/lnd/lnd.go
@@ -351,8 +351,6 @@ func (l Backend) GetChannelInfo(ctx context.Context, channel *models.Channel) er
 
 	t := time.Unix(int64(uint64(resp.LastUpdate)), 0)
 	channel.LastUpdate = &t
-	channel.Policy1 = protoToRoutingPolicy(resp.Node1Policy)
-	channel.Policy2 = protoToRoutingPolicy(resp.Node2Policy)
 
 	info, err := clt.GetInfo(ctx, &lnrpc.GetInfoRequest{})
 	if err != nil {
@@ -360,6 +358,13 @@ func (l Backend) GetChannelInfo(ctx context.Context, channel *models.Channel) er
 	}
 	if info != nil {
 		channel.WeFirst = resp.Node1Pub == info.IdentityPubkey
+	}
+	if channel.WeFirst {
+		channel.LocalPolicy = protoToRoutingPolicy(resp.Node1Policy)
+		channel.RemotePolicy = protoToRoutingPolicy(resp.Node2Policy)
+	} else {
+		channel.LocalPolicy = protoToRoutingPolicy(resp.Node2Policy)
+		channel.RemotePolicy = protoToRoutingPolicy(resp.Node1Policy)
 	}
 
 	return nil

--- a/network/models/channel.go
+++ b/network/models/channel.go
@@ -48,8 +48,8 @@ type Channel struct {
 	LastUpdate          *time.Time
 	Node                *Node
 	WeFirst             bool
-	Policy1             *RoutingPolicy
-	Policy2             *RoutingPolicy
+	LocalPolicy         *RoutingPolicy
+	RemotePolicy        *RoutingPolicy
 }
 
 func (m Channel) MarshalLogObject(enc logging.ObjectEncoder) error {

--- a/ui/models/channels.go
+++ b/ui/models/channels.go
@@ -108,12 +108,12 @@ func (c *Channels) Update(newChannel *models.Channel) {
 		oldChannel.LastUpdate = newChannel.LastUpdate
 	}
 
-	if newChannel.Policy1 != nil {
-		oldChannel.Policy1 = newChannel.Policy1
+	if newChannel.LocalPolicy != nil {
+		oldChannel.LocalPolicy = newChannel.LocalPolicy
 	}
 
-	if newChannel.Policy2 != nil {
-		oldChannel.Policy2 = newChannel.Policy2
+	if newChannel.RemotePolicy != nil {
+		oldChannel.RemotePolicy = newChannel.RemotePolicy
 	}
 }
 

--- a/ui/views/channel.go
+++ b/ui/views/channel.go
@@ -148,6 +148,7 @@ func (c *Channel) display() {
 	channel := c.channels.Current()
 	green := color.Green()
 	cyan := color.Cyan()
+
 	fmt.Fprintln(v, green(" [ Channel ]"))
 	fmt.Fprintf(v, "%s %s\n",
 		cyan("         Status:"), status(channel))
@@ -161,7 +162,9 @@ func (c *Channel) display() {
 		cyan(" Remote Balance:"), channel.RemoteBalance)
 	fmt.Fprintf(v, "%s %s\n",
 		cyan("  Channel Point:"), channel.ChannelPoint)
+
 	fmt.Fprintln(v, "")
+
 	fmt.Fprintln(v, green(" [ Node ]"))
 	fmt.Fprintf(v, "%s %s\n",
 		cyan("         PubKey:"), channel.RemotePubKey)
@@ -178,17 +181,11 @@ func (c *Channel) display() {
 		fmt.Fprintf(v, "%s %d\n",
 			cyan(" Total Channels:"), channel.Node.NumChannels)
 	}
-
-	if channel.Policy1 != nil && channel.WeFirst {
-		printPolicy(v, p, channel.Policy1, true)
+	if channel.LocalPolicy != nil {
+		printPolicy(v, p, channel.LocalPolicy, true)
 	}
-
-	if channel.Policy2 != nil {
-		printPolicy(v, p, channel.Policy2, !channel.WeFirst)
-	}
-
-	if channel.Policy1 != nil && !channel.WeFirst {
-		printPolicy(v, p, channel.Policy1, false)
+	if channel.RemotePolicy != nil {
+		printPolicy(v, p, channel.RemotePolicy, false)
 	}
 	if len(channel.PendingHTLC) > 0 {
 		fmt.Fprintln(v)

--- a/ui/views/channels.go
+++ b/ui/views/channels.go
@@ -546,19 +546,19 @@ func NewChannels(cfg *config.View, chans *models.Channels) *Channels {
 					return func(c1, c2 *netmodels.Channel) bool {
 						var c1f uint64
 						var c2f uint64
-						if c1.Policy1 != nil {
-							c1f = uint64(c1.Policy1.FeeBaseMsat)
+						if c1.LocalPolicy != nil {
+							c1f = uint64(c1.LocalPolicy.FeeBaseMsat)
 						}
-						if c2.Policy1 != nil {
-							c2f = uint64(c2.Policy1.FeeBaseMsat)
+						if c2.LocalPolicy != nil {
+							c2f = uint64(c2.LocalPolicy.FeeBaseMsat)
 						}
 						return models.UInt64Sort(c1f, c2f, order)
 					}
 				},
 				display: func(c *netmodels.Channel, opts ...color.Option) string {
 					var val int64
-					if c.Policy1 != nil {
-						val = c.Policy1.FeeBaseMsat
+					if c.LocalPolicy != nil {
+						val = c.LocalPolicy.FeeBaseMsat
 					}
 					return color.White(opts...)(printer.Sprintf("%8d", val))
 				},
@@ -571,19 +571,19 @@ func NewChannels(cfg *config.View, chans *models.Channels) *Channels {
 					return func(c1, c2 *netmodels.Channel) bool {
 						var c1f uint64
 						var c2f uint64
-						if c1.Policy1 != nil {
-							c1f = uint64(c1.Policy1.FeeRateMilliMsat)
+						if c1.LocalPolicy != nil {
+							c1f = uint64(c1.LocalPolicy.FeeRateMilliMsat)
 						}
-						if c2.Policy1 != nil {
-							c2f = uint64(c2.Policy1.FeeRateMilliMsat)
+						if c2.LocalPolicy != nil {
+							c2f = uint64(c2.LocalPolicy.FeeRateMilliMsat)
 						}
 						return models.UInt64Sort(c1f, c2f, order)
 					}
 				},
 				display: func(c *netmodels.Channel, opts ...color.Option) string {
 					var val int64
-					if c.Policy1 != nil {
-						val = c.Policy1.FeeRateMilliMsat
+					if c.LocalPolicy != nil {
+						val = c.LocalPolicy.FeeRateMilliMsat
 					}
 					return color.White(opts...)(printer.Sprintf("%8d", val))
 				},
@@ -596,19 +596,19 @@ func NewChannels(cfg *config.View, chans *models.Channels) *Channels {
 					return func(c1, c2 *netmodels.Channel) bool {
 						var c1f uint64
 						var c2f uint64
-						if c1.Policy2 != nil {
-							c1f = uint64(c1.Policy2.FeeBaseMsat)
+						if c1.RemotePolicy != nil {
+							c1f = uint64(c1.RemotePolicy.FeeBaseMsat)
 						}
-						if c2.Policy2 != nil {
-							c2f = uint64(c2.Policy2.FeeBaseMsat)
+						if c2.RemotePolicy != nil {
+							c2f = uint64(c2.RemotePolicy.FeeBaseMsat)
 						}
 						return models.UInt64Sort(c1f, c2f, order)
 					}
 				},
 				display: func(c *netmodels.Channel, opts ...color.Option) string {
 					var val int64
-					if c.Policy2 != nil {
-						val = c.Policy2.FeeBaseMsat
+					if c.RemotePolicy != nil {
+						val = c.RemotePolicy.FeeBaseMsat
 					}
 					return color.White(opts...)(printer.Sprintf("%7d", val))
 				},
@@ -621,19 +621,19 @@ func NewChannels(cfg *config.View, chans *models.Channels) *Channels {
 					return func(c1, c2 *netmodels.Channel) bool {
 						var c1f uint64
 						var c2f uint64
-						if c1.Policy2 != nil {
-							c1f = uint64(c1.Policy2.FeeRateMilliMsat)
+						if c1.RemotePolicy != nil {
+							c1f = uint64(c1.RemotePolicy.FeeRateMilliMsat)
 						}
-						if c2.Policy2 != nil {
-							c2f = uint64(c2.Policy2.FeeRateMilliMsat)
+						if c2.RemotePolicy != nil {
+							c2f = uint64(c2.RemotePolicy.FeeRateMilliMsat)
 						}
 						return models.UInt64Sort(c1f, c2f, order)
 					}
 				},
 				display: func(c *netmodels.Channel, opts ...color.Option) string {
 					var val int64
-					if c.Policy2 != nil {
-						val = c.Policy2.FeeRateMilliMsat
+					if c.RemotePolicy != nil {
+						val = c.RemotePolicy.FeeRateMilliMsat
 					}
 					return color.White(opts...)(printer.Sprintf("%7d", val))
 				},


### PR DESCRIPTION
This PR fixes https://github.com/edouardparis/lntop/issues/84 in which the order of channel fees in the channel overview pane (BASE_(IN/OUt), RATE_(IN/OUT)) appear to be flipped.
<img width="673" alt="image" src="https://user-images.githubusercontent.com/18631614/189730976-11eef4f7-749a-4a22-b4fa-6635ad1daf88.png">

Additionally this PR replaces `Policy1` and `Policy2` with `LocalPolicy` and `RemotePolicy` to allow for easier handling in the `lntop` code base.

We also now keep the order of channel policy in the single channel view fixed, namely first `[ Outgoing Policy ]` then `[ Incoming Policy ]`.
<img width="759" alt="image" src="https://user-images.githubusercontent.com/18631614/189731996-fd5d9445-78ce-41f5-b15a-fb702764fbbb.png">

