### PR TITLE
Fix prematurely closing events channel

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -71,6 +71,8 @@ func run(c *cli.Context) error {
 	}()
 
 	ps.Run(ctx, events)
+	close(events)
+
 	return nil
 }
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -34,7 +34,6 @@ func Run(ctx context.Context, app *app.App, sub chan *events.Event) error {
 	go ctrl.Listen(ctx, g, sub)
 
 	err = g.MainLoop()
-	close(sub)
 
 	return errors.WithStack(err)
 }


### PR DESCRIPTION
This PR seeks to address issue https://github.com/edouardparis/lntop/issues/77 by closing the events channel in the main client routing `cli.Run` after all subroutines exited.