### PR TITLE
fix: check UnknownView error in routing delete method

### DIFF
--- a/ui/views/routing.go
+++ b/ui/views/routing.go
@@ -167,18 +167,18 @@ func (c Routing) Index() int {
 
 func (c *Routing) Delete(g *gocui.Gui) error {
 	err := g.DeleteView(ROUTING_COLUMNS)
-	if err != nil {
+	if err != nil && err != gocui.ErrUnknownView {
 		return err
 	}
 
 	err = g.DeleteView(ROUTING)
-	if err != nil {
+	if err != nil && err != gocui.ErrUnknownView {
 		return err
 	}
 
 	for _, cv := range c.columnViews {
 		err = g.DeleteView(cv.Name())
-		if err != nil {
+		if err != nil && err != gocui.ErrUnknownView {
 			return err
 		}
 	}


### PR DESCRIPTION
When deleting the ROUTING view, every sub-view are being deleted. gocui returns ErrUnknownView if the view was not created, we can safely ignore this error.