### PR TITLE
Update channel maturity

### DIFF
--- a/ui/models/channels.go
+++ b/ui/models/channels.go
@@ -105,6 +105,7 @@ func (c *Channels) Update(newChannel *models.Channel) {
 	oldChannel.Private = newChannel.Private
 	oldChannel.PendingHTLC = newChannel.PendingHTLC
 	oldChannel.Age = newChannel.Age
+	oldChannel.BlocksTilMaturity = newChannel.BlocksTilMaturity
 
 	if newChannel.LastUpdate != nil {
 		oldChannel.LastUpdate = newChannel.LastUpdate


### PR DESCRIPTION
The maturity field added in #92 isn't updated when the channel is updated. Because of that it's useless since it shows a stale number that should update on every block to be useful. This PR fixes it.